### PR TITLE
Add foundational Python CLI with transaction tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,9 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+
+# Python artifacts
+__pycache__/
+*.pyc
+finance.db
+.env

--- a/finance_cli/__init__.py
+++ b/finance_cli/__init__.py
@@ -1,0 +1,3 @@
+"""Finance CLI package."""
+
+__all__ = []

--- a/finance_cli/cli.py
+++ b/finance_cli/cli.py
@@ -1,0 +1,44 @@
+"""Command line interface for Finance CLI."""
+from __future__ import annotations
+
+from datetime import datetime
+
+import questionary
+
+from .database import add_transaction, get_transactions, init_db
+
+
+def main() -> None:
+    """Entry point for the Finance CLI."""
+    init_db()
+    while True:
+        choice = questionary.select(
+            "Choose an option:",
+            choices=["Enter transaction", "List transactions", "Quit"],
+        ).ask()
+
+        if choice == "Enter transaction":
+            description = questionary.text("Description:").ask()
+            amount_str = questionary.text("Amount:").ask()
+            try:
+                amount = float(amount_str)
+            except ValueError:
+                print("Invalid amount. Please enter a numeric value.")
+                continue
+            add_transaction(description=description, amount=amount, date=datetime.utcnow())
+            print("Transaction saved.\n")
+        elif choice == "List transactions":
+            txns = get_transactions()
+            if not txns:
+                print("No transactions recorded.\n")
+            else:
+                for txn in txns:
+                    print(f"{txn.date:%Y-%m-%d %H:%M} - {txn.description}: ${txn.amount:.2f}")
+                print()
+            questionary.press_any_key("Press any key to return to menu").ask()
+        else:
+            break
+
+
+if __name__ == "__main__":
+    main()

--- a/finance_cli/database.py
+++ b/finance_cli/database.py
@@ -1,0 +1,57 @@
+"""Database models and access layer for Finance CLI."""
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import List
+
+from sqlalchemy import Column, DateTime, Float, Integer, String, create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker, Session
+
+# Configure database URL via environment variable for flexibility
+DATABASE_URL = os.environ.get("FINANCE_DB", "sqlite:///finance.db")
+
+engine = create_engine(DATABASE_URL, future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False)
+Base = declarative_base()
+
+
+class Transaction(Base):
+    """Represents a financial transaction."""
+
+    __tablename__ = "transactions"
+
+    id: int = Column(Integer, primary_key=True)
+    description: str = Column(String, nullable=False)
+    amount: float = Column(Float, nullable=False)
+    date: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+
+def init_db() -> None:
+    """Initialise the database schema."""
+    Base.metadata.create_all(bind=engine)
+
+
+def get_session() -> Session:
+    """Create a new database session."""
+    return SessionLocal()
+
+
+def add_transaction(description: str, amount: float, date: datetime | None = None) -> None:
+    """Persist a new transaction."""
+    session = get_session()
+    try:
+        txn = Transaction(description=description, amount=amount, date=date or datetime.utcnow())
+        session.add(txn)
+        session.commit()
+    finally:
+        session.close()
+
+
+def get_transactions() -> List[Transaction]:
+    """Fetch all transactions ordered by date descending."""
+    session = get_session()
+    try:
+        return session.query(Transaction).order_by(Transaction.date.desc()).all()
+    finally:
+        session.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+questionary
+sqlalchemy
+pytest

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,27 @@
+import os
+import sys
+from datetime import datetime
+
+import pytest
+
+# Ensure package root is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Configure database path for testing before importing database module
+@pytest.fixture(autouse=True)
+def _set_test_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("FINANCE_DB", f"sqlite:///{db_path}")
+    yield
+
+
+def test_add_and_get_transactions():
+    from finance_cli import database
+
+    database.init_db()
+    database.add_transaction("Coffee", 3.50, datetime(2023, 1, 1))
+
+    txns = database.get_transactions()
+    assert len(txns) == 1
+    assert txns[0].description == "Coffee"
+    assert txns[0].amount == 3.50


### PR DESCRIPTION
## Summary
- introduce `finance_cli` package with a questionary-powered menu for entering and listing transactions
- persist transactions in a SQLite database using SQLAlchemy for future budgeting features
- include pytest-based unit test for transaction persistence

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68924d72256c8328832291929ef20cfc