### PR TITLE
Enable interactive transaction editing

### DIFF
--- a/budget/cli.py
+++ b/budget/cli.py
@@ -9,40 +9,103 @@ from .database import SessionLocal, init_db
 from .models import Transaction
 
 
+def transaction_form(
+    description: str, timestamp: datetime, amount: float
+):
+    """Interactive form for editing transaction fields.
+
+    Returns ``(description, timestamp, amount)`` if saved, otherwise ``None``.
+    """
+
+    while True:
+        choice = questionary.select(
+            "Select field to edit",
+            choices=[
+                questionary.Choice(title=f"Name: {description}", value="description"),
+                questionary.Choice(
+                    title=f"Date: {timestamp.strftime('%Y-%m-%d')}", value="date"
+                ),
+                questionary.Choice(title=f"Amount: {amount}", value="amount"),
+                questionary.Choice(title="Save", value="save"),
+                questionary.Choice(title="Cancel", value="cancel"),
+            ],
+        ).ask()
+
+        if choice == "description":
+            new_desc = questionary.text("Description", default=description).ask()
+            if new_desc is not None:
+                description = new_desc
+        elif choice == "date":
+            date_str = questionary.text(
+                "Date (YYYY-MM-DD)", default=timestamp.strftime("%Y-%m-%d")
+            ).ask()
+            if date_str is not None:
+                try:
+                    timestamp = datetime.strptime(date_str, "%Y-%m-%d")
+                except ValueError:
+                    print("Invalid date format. Use YYYY-MM-DD.")
+        elif choice == "amount":
+            amount_str = questionary.text("Amount", default=str(amount)).ask()
+            if amount_str is not None:
+                try:
+                    amount = float(amount_str)
+                except ValueError:
+                    print("Invalid amount.")
+        elif choice == "save":
+            return description, timestamp, amount
+        else:
+            return None
+
+
 def add_transaction() -> None:
     """Prompt user for transaction data and persist it."""
-    description = questionary.text("Description").ask()
-    if description is None:
+    form = transaction_form("", datetime.utcnow(), 0.0)
+    if form is None:
         return
-    amount_str = questionary.text("Amount").ask()
-    if amount_str is None:
-        return
-    try:
-        amount = float(amount_str)
-    except ValueError:
-        print("Invalid amount. Transaction cancelled.")
-        return
+    description, timestamp, amount = form
     session = SessionLocal()
-    txn = Transaction(description=description, amount=amount, timestamp=datetime.utcnow())
+    txn = Transaction(description=description, amount=amount, timestamp=timestamp)
     session.add(txn)
     session.commit()
     session.close()
     print("Transaction recorded.\n")
 
 
+def edit_transaction(session, txn: Transaction) -> None:
+    """Edit an existing transaction in-place."""
+    form = transaction_form(txn.description, txn.timestamp, txn.amount)
+    if form is None:
+        return
+    description, timestamp, amount = form
+    txn.description = description
+    txn.timestamp = timestamp
+    txn.amount = amount
+    session.commit()
+
+
 def list_transactions() -> None:
-    """List all transactions in the database."""
+    """List all transactions in the database and allow editing."""
     session = SessionLocal()
-    txns = session.query(Transaction).order_by(Transaction.timestamp).all()
-    if not txns:
-        print("No transactions recorded yet.\n")
-    else:
-        for txn in txns:
-            ts = txn.timestamp.strftime("%Y-%m-%d %H:%M")
-            print(f"{ts} | {txn.description} | ${txn.amount:.2f}")
-        print()
+    while True:
+        txns = session.query(Transaction).order_by(Transaction.timestamp).all()
+        if not txns:
+            print("No transactions recorded yet.\n")
+            break
+        choices = [
+            questionary.Choice(
+                title=f"{t.timestamp.strftime('%Y-%m-%d %H:%M')} | {t.description} | ${t.amount:.2f}",
+                value=t.id,
+            )
+            for t in txns
+        ]
+        choices.append(questionary.Choice(title="Back", value=None))
+        choice = questionary.select("Select transaction to edit", choices=choices).ask()
+        if choice is None:
+            break
+        txn = session.get(Transaction, choice)
+        if txn is not None:
+            edit_transaction(session, txn)
     session.close()
-    input("Press Enter to continue...")
 
 
 def main() -> None:

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -2,6 +2,7 @@ import os
 import sys
 import tempfile
 from pathlib import Path
+from datetime import datetime
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -9,7 +10,9 @@ from sqlalchemy.orm import sessionmaker
 # Ensure the project root is on the Python path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from budget import database
+import questionary
+
+from budget import cli, database
 from budget.models import Transaction
 
 
@@ -37,4 +40,69 @@ def test_transaction_persistence():
         assert results[0].description == "Test"
         assert results[0].amount == 10.5
     finally:
+        path.unlink()
+
+
+def make_prompt(responses):
+    iterator = iter(responses)
+
+    def _prompt(*args, **kwargs):
+        class Prompt:
+            def ask(self):
+                return next(iterator)
+
+        return Prompt()
+
+    return _prompt
+
+
+def test_add_transaction_with_date(monkeypatch):
+    Session, path = get_temp_session()
+    try:
+        monkeypatch.setattr(cli, "SessionLocal", Session)
+        monkeypatch.setattr(
+            questionary, "select", make_prompt(["description", "date", "amount", "save"])
+        )
+        monkeypatch.setattr(
+            questionary, "text", make_prompt(["Groceries", "2023-02-01", "20.5"])
+        )
+
+        cli.add_transaction()
+
+        session = Session()
+        txns = session.query(Transaction).all()
+        assert len(txns) == 1
+        txn = txns[0]
+        assert txn.description == "Groceries"
+        assert txn.amount == 20.5
+        assert txn.timestamp.date() == datetime(2023, 2, 1).date()
+    finally:
+        session.close()
+        path.unlink()
+
+
+def test_edit_transaction(monkeypatch):
+    Session, path = get_temp_session()
+    try:
+        session = Session()
+        txn = Transaction(
+            description="Old", amount=5.0, timestamp=datetime(2023, 1, 1)
+        )
+        session.add(txn)
+        session.commit()
+
+        monkeypatch.setattr(
+            questionary, "select", make_prompt(["description", "amount", "date", "save"])
+        )
+        monkeypatch.setattr(
+            questionary, "text", make_prompt(["New", "10.0", "2023-03-03"])
+        )
+
+        cli.edit_transaction(session, txn)
+        session.refresh(txn)
+        assert txn.description == "New"
+        assert txn.amount == 10.0
+        assert txn.timestamp.date() == datetime(2023, 3, 3).date()
+    finally:
+        session.close()
         path.unlink()


### PR DESCRIPTION
## Summary
- Allow choosing transactions from the list and editing name, date or amount
- Add date editing to transaction creation
- Introduce reusable transaction editing form for CLI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689261af4c7883288c2890da16f9f918