### PR TITLE
Add balance storage and ledger view

### DIFF
--- a/budget/cli.py
+++ b/budget/cli.py
@@ -161,7 +161,6 @@ def ledger_view() -> None:
             "Ledger",
             choices=choices,
             default=default_entry,
-            page_size=5,
         ).ask()
         if choice == "Exit" or choice is None:
             break

--- a/budget/cli.py
+++ b/budget/cli.py
@@ -9,10 +9,12 @@ from .database import SessionLocal, init_db
 from .models import Transaction, Balance
 
 
-def select(message, choices, default=None):
+def select(message, choices, default=None, menu_height=None):
     """Display a menu and return the selected value.
 
-    ``choices`` may be a list of strings or ``(title, value)`` pairs.
+    ``choices`` may be a list of strings or ``(title, value)`` pairs. ``menu_height``
+    controls how many entries are visible at once, enabling a scrollable view when
+    the list exceeds that height.
     """
 
     titles = []
@@ -25,7 +27,13 @@ def select(message, choices, default=None):
         titles.append(title)
         values.append(value)
     index = values.index(default) if default in values else 0
-    menu = TerminalMenu(titles, title=message, cursor_index=index, cycle_cursor=True)
+    menu = TerminalMenu(
+        titles,
+        title=message,
+        cursor_index=index,
+        cycle_cursor=True,
+        menu_height=menu_height,
+    )
     selection = menu.show()
     if selection is None:
         return None
@@ -184,8 +192,14 @@ def ledger_view() -> None:
     session.close()
     choices = ["Exit"] + entries + ["Exit"]
     default_entry = entries[today_idx] if entries else "Exit"
+    header = "date | name | amount | balance"
     while True:
-        choice = select("Ledger", choices=choices, default=default_entry)
+        choice = select(
+            f"Ledger\n{header}",
+            choices=choices,
+            default=default_entry,
+            menu_height=7,
+        )
         if choice == "Exit" or choice is None:
             break
 

--- a/budget/models.py
+++ b/budget/models.py
@@ -13,3 +13,12 @@ class Transaction(Base):
     description = Column(String, nullable=False)
     amount = Column(Float, nullable=False)
     timestamp = Column(DateTime, default=datetime.utcnow)
+
+
+class Balance(Base):
+    """Stores the user's current balance."""
+
+    __tablename__ = "balance"
+
+    id = Column(Integer, primary_key=True, default=1)
+    amount = Column(Float, nullable=False, default=0.0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-questionary
+simple-term-menu
 sqlalchemy

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -13,7 +13,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 import questionary
 
 from budget import cli, database
-from budget.models import Transaction
+from budget.models import Transaction, Balance
 
 
 def get_temp_session():
@@ -105,4 +105,57 @@ def test_edit_transaction(monkeypatch):
         assert txn.timestamp.date() == datetime(2023, 3, 3).date()
     finally:
         session.close()
+        path.unlink()
+
+
+def test_set_balance(monkeypatch):
+    Session, path = get_temp_session()
+    try:
+        monkeypatch.setattr(cli, "SessionLocal", Session)
+        monkeypatch.setattr(questionary, "text", make_prompt(["100.0"]))
+        cli.set_balance()
+        session = Session()
+        bal = session.get(Balance, 1)
+        assert bal is not None
+        assert bal.amount == 100.0
+    finally:
+        session.close()
+        path.unlink()
+
+
+def test_ledger_running_balance(monkeypatch):
+    Session, path = get_temp_session()
+    try:
+        session = Session()
+        session.add_all(
+            [
+                Balance(id=1, amount=100.0),
+                Transaction(description="T1", amount=-10.0, timestamp=datetime(2023, 1, 1)),
+                Transaction(description="T2", amount=20.0, timestamp=datetime(2023, 1, 2)),
+            ]
+        )
+        session.commit()
+        session.close()
+
+        captured = {}
+
+        def fake_select(message, choices, default=None, page_size=None):
+            captured["choices"] = choices
+            captured["default"] = default
+
+            class Prompt:
+                def ask(self):
+                    return "Exit"
+
+            return Prompt()
+
+        monkeypatch.setattr(cli, "SessionLocal", Session)
+        monkeypatch.setattr(questionary, "select", fake_select)
+        cli.ledger_view()
+
+        titles = [c.title if hasattr(c, "title") else c for c in captured["choices"]]
+        assert titles[1].endswith("| -10.00 | 90.00")
+        assert titles[2].endswith("| 20.00 | 110.00")
+        assert captured["default"] == titles[2]
+    finally:
         path.unlink()

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -139,7 +139,7 @@ def test_ledger_running_balance(monkeypatch):
 
         captured = {}
 
-        def fake_select(message, choices, default=None, page_size=None):
+        def fake_select(message, choices, default=None):
             captured["choices"] = choices
             captured["default"] = default
 

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -133,7 +133,7 @@ def test_ledger_running_balance(monkeypatch):
 
         captured = {}
 
-        def fake_select(message, choices, default=None):
+        def fake_select(message, choices, default=None, **kwargs):
             captured["choices"] = choices
             captured["default"] = default
             return "Exit"


### PR DESCRIPTION
## Summary
- allow storing a user's current balance
- add scrollable ledger view with running balance
- expose new CLI options for balance and ledger features

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892702a6afc8328b674917c4ad3cbaa