### PR TITLE
Implement curses-based ledger scrolling

### DIFF
--- a/budget/cli.py
+++ b/budget/cli.py
@@ -1,12 +1,47 @@
 """Command-line interface for budget app."""
 from __future__ import annotations
 
-from datetime import datetime
-
-import questionary
+from datetime import datetime, date
+import curses
 
 from .database import SessionLocal, init_db
-from .models import Transaction
+from .models import Transaction, Balance
+
+
+def select(message, choices, default=None):
+    """Display a scrollable menu and return the selected value.
+
+    ``choices`` may be a list of strings or ``(title, value)`` pairs. The menu
+    is navigated with the arrow keys and the highlighted entry is returned when
+    the user presses Enter. ``default`` selects the initially highlighted value
+    if provided.
+    """
+
+    titles: list[str] = []
+    values = []
+    default_idx = 0
+    for idx, choice in enumerate(choices):
+        if isinstance(choice, tuple):
+            title, value = choice
+        else:
+            title = value = choice
+        titles.append(title)
+        values.append(value)
+        if default is not None and value == default:
+            default_idx = idx
+
+    selected = scroll_menu(titles, default_idx, header=message)
+    return values[selected]
+
+
+def text(message, default=None):
+    """Prompt the user for free-form text input."""
+
+    prompt = f"{message}" + (f" [{default}]" if default is not None else "") + ": "
+    response = input(prompt)
+    if response == "" and default is not None:
+        return default
+    return response
 
 
 def transaction_form(
@@ -18,34 +53,32 @@ def transaction_form(
     """
 
     while True:
-        choice = questionary.select(
+        choice = select(
             "Select field to edit",
             choices=[
-                questionary.Choice(title=f"Name: {description}", value="description"),
-                questionary.Choice(
-                    title=f"Date: {timestamp.strftime('%Y-%m-%d')}", value="date"
-                ),
-                questionary.Choice(title=f"Amount: {amount}", value="amount"),
-                questionary.Choice(title="Save", value="save"),
-                questionary.Choice(title="Cancel", value="cancel"),
+                (f"Name: {description}", "description"),
+                (f"Date: {timestamp.strftime('%Y-%m-%d')}", "date"),
+                (f"Amount: {amount}", "amount"),
+                ("Save", "save"),
+                ("Cancel", "cancel"),
             ],
-        ).ask()
+        )
 
         if choice == "description":
-            new_desc = questionary.text("Description", default=description).ask()
+            new_desc = text("Description", default=description)
             if new_desc is not None:
                 description = new_desc
         elif choice == "date":
-            date_str = questionary.text(
+            date_str = text(
                 "Date (YYYY-MM-DD)", default=timestamp.strftime("%Y-%m-%d")
-            ).ask()
+            )
             if date_str is not None:
                 try:
                     timestamp = datetime.strptime(date_str, "%Y-%m-%d")
                 except ValueError:
                     print("Invalid date format. Use YYYY-MM-DD.")
         elif choice == "amount":
-            amount_str = questionary.text("Amount", default=str(amount)).ask()
+            amount_str = text("Amount", default=str(amount))
             if amount_str is not None:
                 try:
                     amount = float(amount_str)
@@ -91,21 +124,160 @@ def list_transactions() -> None:
         if not txns:
             print("No transactions recorded yet.\n")
             break
+        desc_w = max(len(t.description) for t in txns)
+        amt_w = max(len(f"{t.amount:.2f}") for t in txns)
         choices = [
-            questionary.Choice(
-                title=f"{t.timestamp.strftime('%Y-%m-%d %H:%M')} | {t.description} | ${t.amount:.2f}",
-                value=t.id,
+            (
+                f"{t.timestamp.strftime('%Y-%m-%d')} | {t.description:<{desc_w}} | {t.amount:>{amt_w}.2f}",
+                t.id,
             )
             for t in txns
         ]
-        choices.append(questionary.Choice(title="Back", value=None))
-        choice = questionary.select("Select transaction to edit", choices=choices).ask()
-        if choice == "Back" or choice is None:
+        choices.append(("Back", None))
+        choice = select("Select transaction to edit", choices)
+        if choice is None:
             break
         txn = session.get(Transaction, choice)
         if txn is not None:
             edit_transaction(session, txn)
     session.close()
+
+
+def set_balance() -> None:
+    """Prompt the user to store their current balance."""
+    amount_str = text("Current balance")
+    if amount_str is None:
+        return
+    try:
+        amount = float(amount_str)
+    except ValueError:
+        print("Invalid amount.")
+        return
+    session = SessionLocal()
+    bal = session.get(Balance, 1)
+    if bal is None:
+        bal = Balance(id=1, amount=amount)
+        session.add(bal)
+    else:
+        bal.amount = amount
+    session.commit()
+    session.close()
+
+
+def build_ledger_entries():
+    """Return formatted ledger entries and default index.
+
+    The returned list includes "Exit" at the beginning and end. The default
+    index highlights the most recent past transaction relative to today.
+    """
+
+    session = SessionLocal()
+    txns = session.query(Transaction).order_by(Transaction.timestamp).all()
+    if not txns:
+        session.close()
+        return [], 0
+    bal = session.get(Balance, 1)
+    base = bal.amount if bal else 0.0
+    running_values = []
+    running = base
+    for txn in txns:
+        running += txn.amount
+        running_values.append(running)
+    desc_w = max(len(t.description) for t in txns)
+    amt_w = max(len(f"{t.amount:.2f}") for t in txns)
+    run_w = max(len(f"{r:.2f}") for r in running_values)
+    entries = []
+    today = date.today()
+    today_idx = 0
+    running = base
+    for idx, txn in enumerate(txns):
+        running += txn.amount
+        date_str = txn.timestamp.strftime("%Y-%m-%d")
+        desc = f"{txn.description:<{desc_w}}"
+        amt = f"{txn.amount:>{amt_w}.2f}"
+        run = f"{running:>{run_w}.2f}"
+        entry = f"{date_str} | {desc} | {amt} | {run}"
+        entries.append(entry)
+        if txn.timestamp.date() <= today:
+            today_idx = idx
+    session.close()
+    choices = ["Exit"] + entries + ["Exit"]
+    default_idx = today_idx + 1  # account for leading Exit
+    return choices, default_idx
+
+
+def scroll_menu(entries, index, header: str | None = None):
+    """Display ``entries`` in a curses-driven scrollable window.
+
+    The entire screen (minus a bottom status bar) is used for the list. The
+    bottom bar shows today's date on the left and the stored balance on the
+    right. Navigation is performed with the arrow keys and Enter returns the
+    index of the highlighted entry.
+    """
+
+    def _menu(stdscr):
+        curses.curs_set(0)
+        stdscr.keypad(True)
+
+        bal_session = SessionLocal()
+        bal = bal_session.get(Balance, 1)
+        bal_amt = bal.amount if bal else 0.0
+        bal_session.close()
+
+        h, w = stdscr.getmaxyx()
+        list_h = h - 1 - (1 if header else 0)
+        top = max(0, min(len(entries) - list_h, index - list_h // 2))
+
+        while True:
+            h, w = stdscr.getmaxyx()
+            list_h = h - 1 - (1 if header else 0)
+            stdscr.erase()
+            if header:
+                stdscr.addnstr(0, 0, header, w - 1)
+                start_y = 1
+            else:
+                start_y = 0
+
+            for i in range(list_h):
+                line_idx = top + i
+                if line_idx >= len(entries):
+                    break
+                attr = curses.A_REVERSE if line_idx == index else curses.A_NORMAL
+                stdscr.addnstr(start_y + i, 0, entries[line_idx], w - 1, attr)
+
+            date_str = date.today().isoformat()
+            bal_str = f"{bal_amt:.2f}"
+            stdscr.addnstr(h - 1, 0, date_str, w - 1)
+            stdscr.addnstr(h - 1, max(0, w - len(bal_str)), bal_str, len(bal_str))
+            stdscr.refresh()
+
+            key = stdscr.getch()
+            if key == curses.KEY_UP and index > 0:
+                index -= 1
+            elif key == curses.KEY_DOWN and index < len(entries) - 1:
+                index += 1
+            elif key in (curses.KEY_ENTER, 10, 13):
+                return index
+
+            if index < top:
+                top = index
+            elif index >= top + list_h:
+                top = index - list_h + 1
+
+    return curses.wrapper(_menu)
+
+
+def ledger_view() -> None:
+    """Display a scrollable ledger as ``date | name | amount | balance``."""
+
+    entries, index = build_ledger_entries()
+    if not entries:
+        print("No transactions recorded yet.\n")
+        return
+    while True:
+        index = scroll_menu(entries, index)
+        if entries[index] == "Exit":
+            break
 
 
 def edit_wants_goals() -> None:
@@ -129,7 +301,7 @@ def add_wants_goals() -> None:
 def wants_goals_menu() -> None:
     """Secondary menu for wants/goals related actions."""
     while True:
-        choice = questionary.select(
+        choice = select(
             "Wants/Goals options",
             choices=[
                 "Edit wants/goals",
@@ -137,7 +309,7 @@ def wants_goals_menu() -> None:
                 "Add wants/goals",
                 "Back",
             ],
-        ).ask()
+        )
         if choice == "Edit wants/goals":
             edit_wants_goals()
         elif choice == "Toggle wants/goals":
@@ -151,19 +323,25 @@ def wants_goals_menu() -> None:
 def main() -> None:
     init_db()
     while True:
-        choice = questionary.select(
+        choice = select(
             "Select an option",
             choices=[
                 "Enter transaction",
                 "List transactions",
+                "Ledger",
+                "Set balance",
                 "Wants/Goals",
                 "Quit",
             ],
-        ).ask()
+        )
         if choice == "Enter transaction":
             add_transaction()
         elif choice == "List transactions":
             list_transactions()
+        elif choice == "Ledger":
+            ledger_view()
+        elif choice == "Set balance":
+            set_balance()
         elif choice == "Wants/Goals":
             wants_goals_menu()
         else:

--- a/budget/models.py
+++ b/budget/models.py
@@ -13,3 +13,12 @@ class Transaction(Base):
     description = Column(String, nullable=False)
     amount = Column(Float, nullable=False)
     timestamp = Column(DateTime, default=datetime.utcnow)
+
+
+class Balance(Base):
+    """Stores the user's current balance."""
+
+    __tablename__ = "balance"
+
+    id = Column(Integer, primary_key=True, default=1)
+    amount = Column(Float, nullable=False, default=0.0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-questionary
 sqlalchemy

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -10,10 +10,8 @@ from sqlalchemy.orm import sessionmaker
 # Ensure the project root is on the Python path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-import questionary
-
 from budget import cli, database
-from budget.models import Transaction
+from budget.models import Transaction, Balance
 
 
 def get_temp_session():
@@ -47,11 +45,7 @@ def make_prompt(responses):
     iterator = iter(responses)
 
     def _prompt(*args, **kwargs):
-        class Prompt:
-            def ask(self):
-                return next(iterator)
-
-        return Prompt()
+        return next(iterator)
 
     return _prompt
 
@@ -61,10 +55,10 @@ def test_add_transaction_with_date(monkeypatch):
     try:
         monkeypatch.setattr(cli, "SessionLocal", Session)
         monkeypatch.setattr(
-            questionary, "select", make_prompt(["description", "date", "amount", "save"])
+            cli, "select", make_prompt(["description", "date", "amount", "save"])
         )
         monkeypatch.setattr(
-            questionary, "text", make_prompt(["Groceries", "2023-02-01", "20.5"])
+            cli, "text", make_prompt(["Groceries", "2023-02-01", "20.5"])
         )
 
         cli.add_transaction()
@@ -92,10 +86,10 @@ def test_edit_transaction(monkeypatch):
         session.commit()
 
         monkeypatch.setattr(
-            questionary, "select", make_prompt(["description", "amount", "date", "save"])
+            cli, "select", make_prompt(["description", "amount", "date", "save"])
         )
         monkeypatch.setattr(
-            questionary, "text", make_prompt(["New", "10.0", "2023-03-03"])
+            cli, "text", make_prompt(["New", "10.0", "2023-03-03"])
         )
 
         cli.edit_transaction(session, txn)
@@ -106,3 +100,109 @@ def test_edit_transaction(monkeypatch):
     finally:
         session.close()
         path.unlink()
+
+
+def test_set_balance(monkeypatch):
+    Session, path = get_temp_session()
+    try:
+        monkeypatch.setattr(cli, "SessionLocal", Session)
+        monkeypatch.setattr(cli, "text", make_prompt(["100.0"]))
+        cli.set_balance()
+        session = Session()
+        bal = session.get(Balance, 1)
+        assert bal is not None
+        assert bal.amount == 100.0
+    finally:
+        session.close()
+        path.unlink()
+
+
+def test_ledger_running_balance(monkeypatch):
+    Session, path = get_temp_session()
+    try:
+        session = Session()
+        session.add_all(
+            [
+                Balance(id=1, amount=100.0),
+                Transaction(description="T1", amount=-10.0, timestamp=datetime(2023, 1, 1)),
+                Transaction(description="T2", amount=20.0, timestamp=datetime(2023, 1, 2)),
+            ]
+        )
+        session.commit()
+        session.close()
+
+        captured = {}
+
+        def fake_scroll(entries, index, header=None):
+            captured["entries"] = entries
+            captured["index"] = index
+            captured["header"] = header
+            # return bottom "Exit" to exit immediately
+            return len(entries) - 1
+
+        monkeypatch.setattr(cli, "SessionLocal", Session)
+        monkeypatch.setattr(cli, "scroll_menu", fake_scroll)
+        cli.ledger_view()
+
+        titles = captured["entries"]
+        assert titles[0] == "Exit"
+        assert titles[1] == "2023-01-01 | T1 | -10.00 |  90.00"
+        assert titles[2] == "2023-01-02 | T2 |  20.00 | 110.00"
+        assert titles[3] == "Exit"
+        assert captured["index"] == 2
+        assert captured["header"] is None
+    finally:
+        path.unlink()
+
+
+def test_list_transactions_columns(monkeypatch):
+    Session, path = get_temp_session()
+    try:
+        session = Session()
+        session.add_all(
+            [
+                Transaction(description="Short", amount=5.0, timestamp=datetime(2023, 1, 1)),
+                Transaction(description="Longer", amount=-3.0, timestamp=datetime(2023, 1, 2)),
+            ]
+        )
+        session.commit()
+        session.close()
+
+        captured = {}
+
+        def fake_select(message, choices, default=None):
+            captured["choices"] = choices
+            return None
+
+        monkeypatch.setattr(cli, "SessionLocal", Session)
+        monkeypatch.setattr(cli, "select", fake_select)
+
+        cli.list_transactions()
+
+        titles = [title for title, _ in captured["choices"]]
+        assert titles[0] == "2023-01-01 | Short  |  5.00"
+        assert titles[1] == "2023-01-02 | Longer | -3.00"
+        assert titles[2] == "Back"
+    finally:
+        path.unlink()
+
+
+def test_select_uses_scroll_menu(monkeypatch):
+    captured = {}
+
+    def fake_scroll(entries, index, header=None):
+        captured["entries"] = entries
+        captured["index"] = index
+        captured["header"] = header
+        return 1  # choose second item
+
+    monkeypatch.setattr(cli, "scroll_menu", fake_scroll)
+
+    result = cli.select(
+        "Pick", ["A", ("B title", "b"), "C"], default="b"
+    )
+
+    assert captured["entries"] == ["A", "B title", "C"]
+    assert captured["index"] == 1
+    assert captured["header"] == "Pick"
+    assert result == "b"


### PR DESCRIPTION
## Summary
- use curses to render full-screen scroll menus navigated by arrow keys and enter
- append a footer to every menu showing today's date and the stored account balance
- drive the ledger view through the new menu, listing each transaction as `date | name | amount | balance`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892702a6afc8328b674917c4ad3cbaa