### PR TITLE
Add recurring bills and income with ledger support

### DIFF
--- a/budget/models.py
+++ b/budget/models.py
@@ -22,3 +22,15 @@ class Balance(Base):
 
     id = Column(Integer, primary_key=True, default=1)
     amount = Column(Float, nullable=False, default=0.0)
+
+
+class Recurring(Base):
+    """A recurring bill or income entry."""
+
+    __tablename__ = "recurring"
+
+    id = Column(Integer, primary_key=True, index=True)
+    description = Column(String, nullable=False)
+    amount = Column(Float, nullable=False)
+    start_date = Column(DateTime, nullable=False)
+    frequency = Column(String, nullable=False)


### PR DESCRIPTION
## Summary
- support recurring bills and income entries with configurable frequency
- render recurring events alongside transactions in an infinitely scrollable ledger
- allow exiting ledger with `q`

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892b261c4948328b0e47880b61a011c