### PR TITLE
Anchor ledger running balance to recorded snapshot

### DIFF
--- a/budget/models.py
+++ b/budget/models.py
@@ -22,6 +22,7 @@ class Balance(Base):
 
     id = Column(Integer, primary_key=True, default=1)
     amount = Column(Float, nullable=False, default=0.0)
+    timestamp = Column(DateTime, default=datetime.utcnow)
 
 
 class Recurring(Base):


### PR DESCRIPTION
## Summary
- record when a balance is entered to anchor ledger calculations
- compute running balances forward and backward from the recorded balance
- cover ledger balance anchoring with updated tests
- upgrade legacy SQLite files by adding a balance timestamp column on startup

## Testing
- `python - <<'PY'
from budget.models import Balance
from budget.database import init_db, engine
from sqlalchemy import text
init_db()
with engine.connect() as conn:
    cols = [row[1] for row in conn.execute(text('PRAGMA table_info(balance)'))]
print('timestamp' in cols)
from budget.cli import SessionLocal
s=SessionLocal()
print(s.get(Balance,1))
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892c145c81c8328b0cfec3129c08dfc