### PR TITLE
Add monthly recurring frequency option

### DIFF
--- a/budget/cli.py
+++ b/budget/cli.py
@@ -14,6 +14,7 @@ FREQUENCIES = [
     "weekly",
     "biweekly",
     "semi monthly",
+    "monthly",
     "quarterly",
     "semi annually",
     "annually",
@@ -314,6 +315,8 @@ def advance_date(d: date, freq: str) -> date:
         return d + timedelta(weeks=2)
     if freq == "semi monthly":
         return d + timedelta(days=15)
+    if freq == "monthly":
+        return add_months(d, 1)
     if freq == "quarterly":
         return add_months(d, 3)
     if freq == "semi annually":
@@ -330,6 +333,8 @@ def retreat_date(d: date, freq: str) -> date:
         return d - timedelta(weeks=2)
     if freq == "semi monthly":
         return d - timedelta(days=15)
+    if freq == "monthly":
+        return add_months(d, -1)
     if freq == "quarterly":
         return add_months(d, -3)
     if freq == "semi annually":
@@ -355,7 +360,7 @@ def occurrence_on_or_before(start: date, freq: str, target: date) -> date | None
     if freq == "semi monthly":
         days = (target - start).days // 15
         return start + timedelta(days=days * 15)
-    step_map = {"quarterly": 3, "semi annually": 6, "annually": 12}
+    step_map = {"monthly": 1, "quarterly": 3, "semi annually": 6, "annually": 12}
     step = step_map.get(freq)
     if step:
         months = months_between(start, target)
@@ -382,7 +387,7 @@ def occurrence_after(start: date, freq: str, after: date) -> date | None:
     if freq == "semi monthly":
         days = (after - start).days // 15 + 1
         return start + timedelta(days=days * 15)
-    step_map = {"quarterly": 3, "semi annually": 6, "annually": 12}
+    step_map = {"monthly": 1, "quarterly": 3, "semi annually": 6, "annually": 12}
     step = step_map.get(freq)
     if step:
         months = months_between(start, after)
@@ -400,7 +405,7 @@ def count_occurrences(start: date, freq: str, target: date) -> int:
         return (target - start).days // 14 + 1
     if freq == "semi monthly":
         return (target - start).days // 15 + 1
-    step_map = {"quarterly": 3, "semi annually": 6, "annually": 12}
+    step_map = {"monthly": 1, "quarterly": 3, "semi annually": 6, "annually": 12}
     step = step_map.get(freq)
     if step:
         months = months_between(start, target)

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -179,6 +179,30 @@ def test_ledger_includes_recurring():
         path.unlink()
 
 
+def test_monthly_recurring_occurs_each_month():
+    Session, path = get_temp_session()
+    try:
+        session = Session()
+        session.add_all(
+            [
+                Balance(id=1, amount=0.0, timestamp=datetime(2023, 1, 1)),
+                Recurring(
+                    description="Rent",
+                    amount=-50.0,
+                    start_date=datetime(2023, 1, 1),
+                    frequency="monthly",
+                ),
+            ]
+        )
+        session.commit()
+        rows = list(itertools.islice(cli.ledger_rows(session), 2))
+        assert rows[0].date == datetime(2023, 1, 1).date()
+        assert rows[1].date == datetime(2023, 2, 1).date()
+    finally:
+        session.close()
+        path.unlink()
+
+
 def test_list_transactions_columns(monkeypatch):
     Session, path = get_temp_session()
     try:


### PR DESCRIPTION
## Summary
- allow selecting a monthly frequency for recurring items
- handle monthly step in date calculations
- test monthly recurring entries appear in ledger

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689370df95f48328a85fcdd742df0eaa