### PR TITLE
Allow quitting menus with q

### DIFF
--- a/budget/cli.py
+++ b/budget/cli.py
@@ -51,6 +51,8 @@ def select(message, choices, default=None):
         header=message,
         footer_right=f"{bal_amt:.2f}",
     )
+    if selected is None:
+        return None
     return values[selected]
 
 
@@ -691,6 +693,8 @@ def scroll_menu(
                 return index
             elif key == ord("a") and allow_add:
                 return -1
+            elif key == ord("q"):
+                return None
 
             if index < top:
                 top = index

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -321,3 +321,61 @@ def test_scroll_menu_handles_curses_error(monkeypatch):
 
     index = cli.scroll_menu(["A", "B"], 0, header="hdr")
     assert index == 0
+
+
+def test_scroll_menu_quits_on_q(monkeypatch):
+    def fake_wrapper(func):
+        class FakeWin:
+            def getmaxyx(self):
+                return (24, 80)
+
+            def addnstr(self, *args, **kwargs):
+                pass
+
+            def addstr(self, *args, **kwargs):
+                pass
+
+            def erase(self):
+                pass
+
+            def refresh(self):
+                pass
+
+            def keypad(self, flag):
+                pass
+
+            def getch(self):
+                return ord("q")
+
+        return func(FakeWin())
+
+    monkeypatch.setattr(cli.curses, "wrapper", fake_wrapper)
+    monkeypatch.setattr(cli.curses, "curs_set", lambda n: None)
+
+    index = cli.scroll_menu(["A", "B"], 0)
+    assert index is None
+
+
+def test_select_returns_none_on_quit(monkeypatch):
+    def fake_scroll(entries, index, header=None, **kwargs):
+        return None
+
+    monkeypatch.setattr(cli, "scroll_menu", fake_scroll)
+
+    class DummySession:
+        def get(self, model, ident):
+            return None
+
+        def close(self):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr(cli, "SessionLocal", lambda: DummySession())
+
+    result = cli.select("Pick", ["A", "B"])
+    assert result is None


### PR DESCRIPTION
## Summary
- Add universal `q` shortcut to leave any curses menu
- Propagate quit from `scroll_menu` through `select`
- Cover `q` handling with new tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68937165135c8328b95db66d2c098d03