### PR TITLE
Add customizable color theme to budget CLI

### DIFF
--- a/budget/cli.py
+++ b/budget/cli.py
@@ -42,6 +42,9 @@ def _apply_theme(stdscr):
         attr = curses.color_pair(1)
         stdscr.bkgd(" ", attr)
         stdscr.attron(attr)
+        stdscr.erase()
+        stdscr.noutrefresh()
+        curses.doupdate()
     except curses.error:
         pass
     return attr

--- a/budget/cli.py
+++ b/budget/cli.py
@@ -905,8 +905,8 @@ def wants_goals_menu() -> None:
 
 def main() -> None:
     init_db()
-    curses.wrapper(_apply_theme)
     while True:
+        curses.wrapper(_apply_theme)
         choice = select(
             "Select an option",
             choices=[


### PR DESCRIPTION
## Summary
- add theme configuration allowing users to enter foreground and background colors as hex codes
- apply chosen theme across curses screens using `bkgd`
- expose new **Theme** option from the main menu

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689374e2a76883288c4e19acea4bf176