### PR TITLE
Optimize database initialization

### DIFF
--- a/budget/database.py
+++ b/budget/database.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from sqlalchemy import create_engine, text
+from sqlalchemy import create_engine, text, inspect
 from sqlalchemy.orm import sessionmaker, declarative_base
 
 # Determine database path; allow override with environment variable for testing
@@ -17,12 +17,21 @@ Base = declarative_base()
 
 def init_db() -> None:
     """Create database tables if they do not exist."""
-    Base.metadata.create_all(engine)
+    insp = inspect(engine)
+    required = {"transactions", "balance", "recurring"}
+    existing = set(insp.get_table_names())
+    if not required.issubset(existing):
+        Base.metadata.create_all(engine)
+        existing = set(insp.get_table_names())
+
     # Ensure legacy databases gain the new balance timestamp column
-    with engine.begin() as conn:
-        cols = [row[1] for row in conn.execute(text("PRAGMA table_info(balance)"))]
-        if "timestamp" not in cols:
-            conn.execute(text("ALTER TABLE balance ADD COLUMN timestamp DATETIME"))
-            conn.execute(
-                text("UPDATE balance SET timestamp = CURRENT_TIMESTAMP WHERE timestamp IS NULL")
-            )
+    if "balance" in existing:
+        with engine.begin() as conn:
+            cols = [row[1] for row in conn.execute(text("PRAGMA table_info(balance)"))]
+            if "timestamp" not in cols:
+                conn.execute(text("ALTER TABLE balance ADD COLUMN timestamp DATETIME"))
+                conn.execute(
+                    text(
+                        "UPDATE balance SET timestamp = CURRENT_TIMESTAMP WHERE timestamp IS NULL"
+                    )
+                )


### PR DESCRIPTION
## Summary
- Avoid unnecessary database schema creation and run migrations only when needed
- Speed up application startup by skipping redundant table setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68940b6b00b88328b31a88638aba7b0f