### PR TITLE
Prevent stale text in curses prompts

### DIFF
--- a/budget/cli.py
+++ b/budget/cli.py
@@ -66,6 +66,14 @@ def text(message, default=None):
         h, w = stdscr.getmaxyx()
         h = max(1, h)
         w = max(1, w)
+        try:
+            stdscr.erase()
+        except Exception:
+            for i in range(h):
+                try:
+                    stdscr.addnstr(i, 0, " " * w, w)
+                except curses.error:
+                    pass
         prompt = f"{message}" + (f" [{default}]" if default is not None else "") + ": "
         y = h // 2
         x = max(0, (w - len(prompt)) // 2)


### PR DESCRIPTION
## Summary
- clear previous prompts in curses text input to avoid stale characters when prompt text shrinks

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68941160f39c8328a1f7ff59274d855a