### PR TITLE
Group ledger events by day

### DIFF
--- a/benchmarks/ledger_benchmark.py
+++ b/benchmarks/ledger_benchmark.py
@@ -1,0 +1,50 @@
+import os
+import time
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from budget import database, cli
+from budget.models import Balance, Transaction
+
+
+def build_session(n_days: int, events_per_day: int):
+    db_fd, db_path = tempfile.mkstemp()
+    os.close(db_fd)
+    engine = create_engine(f"sqlite:///{db_path}", future=True)
+    database.Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    session.add(Balance(id=1, amount=0.0, timestamp=datetime(2023, 1, 1)))
+    start = datetime(2023, 1, 1)
+    txns = []
+    for day in range(n_days):
+        for ev in range(events_per_day):
+            ts = start + timedelta(days=day, minutes=ev)
+            txns.append(Transaction(description=f"T{day}-{ev}", amount=1.0, timestamp=ts))
+    session.add_all(txns)
+    session.commit()
+    return session, Path(db_path)
+
+
+def run():
+    session, path = build_session(365, 3)
+    try:
+        start = time.perf_counter()
+        rows = list(cli.ledger_rows(session))
+        duration = time.perf_counter() - start
+        print(f"Generated {len(rows)} rows in {duration:.4f}s")
+    finally:
+        session.close()
+        path.unlink()
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -203,6 +203,27 @@ def test_monthly_recurring_occurs_each_month():
         path.unlink()
 
 
+def test_ledger_multiple_events_same_day():
+    Session, path = get_temp_session()
+    try:
+        session = Session()
+        session.add_all(
+            [
+                Balance(id=1, amount=100.0, timestamp=datetime(2023, 1, 1)),
+                Transaction(description="A", amount=-10.0, timestamp=datetime(2023, 1, 2, 8)),
+                Transaction(description="B", amount=-5.0, timestamp=datetime(2023, 1, 2, 9)),
+            ]
+        )
+        session.commit()
+        rows = list(cli.ledger_rows(session))
+        assert len(rows) == 2
+        assert rows[0].date == rows[1].date == datetime(2023, 1, 2).date()
+        assert rows[0].running == rows[1].running == 85.0
+    finally:
+        session.close()
+        path.unlink()
+
+
 def test_list_transactions_columns(monkeypatch):
     Session, path = get_temp_session()
     try:


### PR DESCRIPTION
## Summary
- group transactions and recurring events by day with single sticky date rows
- show daily running balance and adjust ledger view navigation
- add benchmark script and test coverage for multiple same-day events

## Testing
- `pytest -q`
- `python benchmarks/ledger_benchmark.py`


------
https://chatgpt.com/codex/tasks/task_e_689415ff776c8328862985cc129938f5