### PR TITLE
Enable deleting entries with confirmation

### DIFF
--- a/budget/cli.py
+++ b/budget/cli.py
@@ -89,6 +89,17 @@ def text(message, default=None):
     return curses.wrapper(_prompt)
 
 
+def confirm(message: str) -> bool:
+    """Prompt the user to confirm an action.
+
+    Returns ``True`` if the user hits Enter without typing anything, otherwise
+    ``False``.
+    """
+
+    resp = input(f"{message} Press Enter to confirm, or any other key to cancel: ")
+    return resp == ""
+
+
 def transaction_form(
     description: str, timestamp: datetime, amount: float
 ):
@@ -219,14 +230,26 @@ def edit_recurring(is_income: bool) -> None:
         entries.append("Back")
         bal = session.get(Balance, 1)
         bal_amt = bal.amount if bal else 0.0
-        idx = scroll_menu(
+        res = scroll_menu(
             entries,
             0,
             header="Edit income" if is_income else "Edit bills",
-            footer_left="Select to edit, 'a' to add",
-             footer_right=f"{bal_amt:.2f}",
+            footer_left="Select to edit, 'a' to add, 'd' to delete",
+            footer_right=f"{bal_amt:.2f}",
             allow_add=True,
+            allow_delete=True,
         )
+        if isinstance(res, tuple) and res[0] == "delete":
+            del_idx = res[1]
+            if del_idx < len(recs):
+                rec = recs[del_idx]
+                if confirm("Delete this item?"):
+                    session.delete(rec)
+                    session.commit()
+            session.close()
+            session = SessionLocal()
+            continue
+        idx = res
         if idx == -1:
             session.close()
             add_recurring(is_income)
@@ -263,20 +286,34 @@ def list_transactions() -> None:
             break
         desc_w = max(len(t.description) for t in txns)
         amt_w = max(len(f"{t.amount:.2f}") for t in txns)
-        choices = [
-            (
-                f"{t.timestamp.strftime('%Y-%m-%d')} | {t.description:<{desc_w}} | {t.amount:>{amt_w}.2f}",
-                t.id,
-            )
+        entries = [
+            f"{t.timestamp.strftime('%Y-%m-%d')} | {t.description:<{desc_w}} | {t.amount:>{amt_w}.2f}"
             for t in txns
         ]
-        choices.append(("Back", None))
-        choice = select("Select transaction to edit", choices)
-        if choice is None:
+        entries.append("Back")
+        bal = session.get(Balance, 1)
+        bal_amt = bal.amount if bal else 0.0
+        res = scroll_menu(
+            entries,
+            0,
+            header="Select transaction to edit",
+            footer_left="Select to edit, 'd' to delete",
+            footer_right=f"{bal_amt:.2f}",
+            allow_delete=True,
+        )
+        if isinstance(res, tuple) and res[0] == "delete":
+            del_idx = res[1]
+            if del_idx < len(txns):
+                txn = txns[del_idx]
+                if confirm("Delete this transaction?"):
+                    session.delete(txn)
+                    session.commit()
+            continue
+        idx = res
+        if idx is None or idx >= len(txns):
             break
-        txn = session.get(Transaction, choice)
-        if txn is not None:
-            edit_transaction(session, txn)
+        txn = txns[idx]
+        edit_transaction(session, txn)
     session.close()
 
 
@@ -634,6 +671,7 @@ def scroll_menu(
     footer_left: str | None = None,
     footer_right: str | None = None,
     allow_add: bool = False,
+    allow_delete: bool = False,
 ):
     """Display ``entries`` in a curses-driven scrollable window.
 
@@ -698,6 +736,8 @@ def scroll_menu(
                 return index
             elif key == ord("a") and allow_add:
                 return -1
+            elif key == ord("d") and allow_delete:
+                return ("delete", index)
             elif key == ord("q"):
                 return None
 

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -13,6 +13,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from budget import cli, database
 from budget.models import Transaction, Balance, Recurring
+import pytest
 
 
 def get_temp_session():
@@ -218,16 +219,16 @@ def test_list_transactions_columns(monkeypatch):
 
         captured = {}
 
-        def fake_select(message, choices, default=None):
-            captured["choices"] = choices
+        def fake_scroll(entries, index, **kwargs):
+            captured["entries"] = entries
             return None
 
         monkeypatch.setattr(cli, "SessionLocal", Session)
-        monkeypatch.setattr(cli, "select", fake_select)
+        monkeypatch.setattr(cli, "scroll_menu", fake_scroll)
 
         cli.list_transactions()
 
-        titles = [title for title, _ in captured["choices"]]
+        titles = captured["entries"]
         assert titles[0] == "2023-01-01 | Short  |  5.00"
         assert titles[1] == "2023-01-02 | Longer | -3.00"
         assert titles[2] == "Back"
@@ -403,3 +404,67 @@ def test_select_returns_none_on_quit(monkeypatch):
 
     result = cli.select("Pick", ["A", "B"])
     assert result is None
+
+
+@pytest.mark.parametrize("is_income, amount", [(False, -10.0), (True, 10.0)])
+def test_delete_recurring(monkeypatch, is_income, amount):
+    Session, path = get_temp_session()
+    try:
+        session = Session()
+        session.add(
+            Recurring(
+                description="R",
+                amount=amount,
+                start_date=datetime(2023, 1, 1),
+                frequency="monthly",
+            )
+        )
+        session.commit()
+        session.close()
+
+        responses = [("delete", 0), None]
+
+        def fake_scroll(entries, index, **kwargs):
+            return responses.pop(0)
+
+        monkeypatch.setattr(cli, "scroll_menu", fake_scroll)
+        monkeypatch.setattr(cli, "SessionLocal", Session)
+        monkeypatch.setattr(cli, "confirm", lambda msg: True)
+
+        cli.edit_recurring(is_income)
+
+        session = Session()
+        assert session.query(Recurring).count() == 0
+    finally:
+        session.close()
+        path.unlink()
+
+
+def test_delete_transaction(monkeypatch):
+    Session, path = get_temp_session()
+    try:
+        session = Session()
+        session.add(
+            Transaction(
+                description="T",
+                amount=5.0,
+                timestamp=datetime(2023, 1, 1),
+            )
+        )
+        session.commit()
+        session.close()
+
+        def fake_scroll(entries, index, **kwargs):
+            return ("delete", 0)
+
+        monkeypatch.setattr(cli, "scroll_menu", fake_scroll)
+        monkeypatch.setattr(cli, "SessionLocal", Session)
+        monkeypatch.setattr(cli, "confirm", lambda msg: True)
+
+        cli.list_transactions()
+
+        session = Session()
+        assert session.query(Transaction).count() == 0
+    finally:
+        session.close()
+        path.unlink()


### PR DESCRIPTION
## Summary
- Allow `d` key to delete items in lists
- Prompt for confirmation before deleting
- Add tests for deleting recurring items and transactions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894aef23a988328940daa67f34c82d0