### PR TITLE
Add interactive goals management

### DIFF
--- a/budget/database.py
+++ b/budget/database.py
@@ -18,7 +18,7 @@ Base = declarative_base()
 def init_db() -> None:
     """Create database tables if they do not exist."""
     insp = inspect(engine)
-    required = {"transactions", "balance", "recurring"}
+    required = {"transactions", "balance", "recurring", "goals"}
     existing = set(insp.get_table_names())
     if not required.issubset(existing):
         Base.metadata.create_all(engine)

--- a/budget/models.py
+++ b/budget/models.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from sqlalchemy import Column, Integer, String, Float, DateTime
+from sqlalchemy import Column, Integer, String, Float, DateTime, Boolean
 
 from .database import Base
 
@@ -35,3 +35,15 @@ class Recurring(Base):
     amount = Column(Float, nullable=False)
     start_date = Column(DateTime, nullable=False)
     frequency = Column(String, nullable=False)
+
+
+class Goal(Base):
+    """A savings goal or want entry."""
+
+    __tablename__ = "goals"
+
+    id = Column(Integer, primary_key=True, index=True)
+    description = Column(String, nullable=False)
+    amount = Column(Float, nullable=False)
+    target_date = Column(DateTime, nullable=False)
+    enabled = Column(Boolean, nullable=False, default=True)

--- a/tests/test_goals.py
+++ b/tests/test_goals.py
@@ -1,0 +1,111 @@
+import os
+import sys
+import tempfile
+from pathlib import Path
+from datetime import datetime
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+# Ensure the project root is on the Python path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from budget import cli, database
+from budget.models import Goal
+
+
+def get_temp_session():
+    db_fd, db_path = tempfile.mkstemp()
+    os.close(db_fd)
+    engine = create_engine(f"sqlite:///{db_path}", future=True)
+    TestingSession = sessionmaker(bind=engine)
+    database.Base.metadata.create_all(engine)
+    return TestingSession, Path(db_path)
+
+
+def make_prompt(responses):
+    iterator = iter(responses)
+
+    def _prompt(*args, **kwargs):
+        return next(iterator)
+
+    return _prompt
+
+
+def test_add_goal(monkeypatch):
+    Session, path = get_temp_session()
+    try:
+        monkeypatch.setattr(cli, "SessionLocal", Session)
+        monkeypatch.setattr(
+            cli,
+            "goal_form",
+            lambda desc, date, amount, enabled: (
+                "Save",
+                datetime(2023, 1, 1),
+                50.0,
+                True,
+            ),
+        )
+        cli.add_goal()
+        session = Session()
+        goals = session.query(Goal).all()
+        assert len(goals) == 1
+        g = goals[0]
+        assert g.description == "Save"
+        assert g.amount == 50.0
+        assert g.target_date.date() == datetime(2023, 1, 1).date()
+        assert g.enabled is True
+    finally:
+        session.close()
+        path.unlink()
+
+
+def test_goal_form_toggle(monkeypatch):
+    monkeypatch.setattr(cli, "select", make_prompt(["enabled", "save"]))
+    monkeypatch.setattr(cli, "text", make_prompt([]))
+    result = cli.goal_form("Desc", datetime(2023, 1, 1), 10.0, True)
+    assert result == ("Desc", datetime(2023, 1, 1), 10.0, False)
+
+
+def test_wants_goals_menu_columns(monkeypatch):
+    Session, path = get_temp_session()
+    try:
+        session = Session()
+        session.add_all(
+            [
+                Goal(
+                    description="G1",
+                    amount=10.0,
+                    target_date=datetime(2023, 1, 1),
+                    enabled=True,
+                ),
+                Goal(
+                    description="G2",
+                    amount=5.5,
+                    target_date=datetime(2023, 1, 2),
+                    enabled=False,
+                ),
+            ]
+        )
+        session.commit()
+        session.close()
+
+        captured = {}
+
+        def fake_curses(entries, index, header=None, footer_right=""):
+            captured["entries"] = entries
+            captured["index"] = index
+            return ("quit", None)
+
+        monkeypatch.setattr(cli, "SessionLocal", Session)
+        monkeypatch.setattr(cli, "goals_curses", fake_curses)
+
+        cli.wants_goals_menu()
+
+        first = captured["entries"][0].split("|")
+        assert first[0].strip() == "2023-01-01"
+        assert first[1].strip() == "10.00"
+        assert first[2].strip() == "on"
+    finally:
+        path.unlink()
+


### PR DESCRIPTION
## Summary
- add `Goal` model with amount, target date, and enabled flag
- list goals with add, edit, delete, and toggle controls
- cover goal workflows with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894b05f7118832895b248a3d92b7c11