### PR TITLE
Use iterator for delete scroll menu

### DIFF
--- a/tests/test_transaction_actions.py
+++ b/tests/test_transaction_actions.py
@@ -140,8 +140,10 @@ def test_delete_transaction(monkeypatch):
         session.commit()
         session.close()
 
+        responses = iter([("delete", 0), None])
+
         def fake_scroll(entries, index, **kwargs):
-            return ("delete", 0)
+            return next(responses)
 
         monkeypatch.setattr(cli, "scroll_menu", fake_scroll)
         monkeypatch.setattr(cli, "SessionLocal", Session)


### PR DESCRIPTION
## Summary
- ensure `test_delete_transaction` uses an iterator-based `fake_scroll`

## Testing
- `pytest tests/test_transaction_actions.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68954a556c288328ae34a668f3ef6bd6