### PR TITLE
Reduce curses flicker with synchronized screen updates

### DIFF
--- a/budget/cli.py
+++ b/budget/cli.py
@@ -90,7 +90,9 @@ def text(message, default=None):
             win.addnstr(1, 2, prompt, box_width - 4)
         except curses.error:
             pass
-        win.refresh()
+        stdscr.noutrefresh()
+        win.noutrefresh()
+        curses.doupdate()
         curses.echo()
         try:
             resp = win.getstr(1, 2 + len(prompt), input_width)
@@ -121,7 +123,9 @@ def confirm(message: str) -> bool:
                 win.addnstr(1 + idx, x, line, max_line)
             except curses.error:
                 pass
-        win.refresh()
+        stdscr.noutrefresh()
+        win.noutrefresh()
+        curses.doupdate()
         ch = win.getch()
         return ch in (curses.KEY_ENTER, 10, 13)
 
@@ -756,7 +760,8 @@ def ledger_curses(initial_row, get_prev, get_next, bal_amt):
                 )
             except curses.error:
                 pass
-            stdscr.refresh()
+            stdscr.noutrefresh()
+            curses.doupdate()
 
             key = stdscr.getch()
             if key == curses.KEY_UP:
@@ -866,7 +871,9 @@ def scroll_menu(
                     )
                 except curses.error:
                     pass
-                win.refresh()
+                stdscr.noutrefresh()
+                win.noutrefresh()
+                curses.doupdate()
                 key = win.getch()
             else:
                 stdscr.erase()
@@ -897,7 +904,8 @@ def scroll_menu(
                     )
                 except curses.error:
                     pass
-                stdscr.refresh()
+                stdscr.noutrefresh()
+                curses.doupdate()
                 key = stdscr.getch()
 
             if key == curses.KEY_UP and index > 0:
@@ -1003,7 +1011,8 @@ def goals_curses(entries, index, header=None, footer_right=""):
                 )
             except curses.error:
                 pass
-            stdscr.refresh()
+            stdscr.noutrefresh()
+            curses.doupdate()
 
             key = stdscr.getch()
             if key == curses.KEY_UP and index > 0:

--- a/tests/test_ui_components.py
+++ b/tests/test_ui_components.py
@@ -51,6 +51,9 @@ def test_text_prompt_curses(monkeypatch):
             def keypad(self, flag):
                 pass
 
+            def noutrefresh(self):
+                pass
+
         return func(FakeStdScr())
 
     def fake_newwin(h, w, y, x):
@@ -61,7 +64,7 @@ def test_text_prompt_curses(monkeypatch):
             def addnstr(self, *args, **kwargs):
                 pass
 
-            def refresh(self):
+            def noutrefresh(self):
                 pass
 
             def getstr(self, y, x, n):
@@ -77,6 +80,7 @@ def test_text_prompt_curses(monkeypatch):
     monkeypatch.setattr(cli.curses, "echo", lambda: None)
     monkeypatch.setattr(cli.curses, "noecho", lambda: None)
     monkeypatch.setattr(cli.curses, "newwin", fake_newwin)
+    monkeypatch.setattr(cli.curses, "doupdate", lambda: None)
 
     assert cli.text("Prompt") == "hello"
     assert cli.text("Prompt", default="dflt") == "dflt"
@@ -93,6 +97,9 @@ def test_confirm_prompt_curses(monkeypatch):
             def keypad(self, flag):
                 pass
 
+            def noutrefresh(self):
+                pass
+
         return func(FakeStdScr())
 
     def fake_newwin(h, w, y, x):
@@ -103,7 +110,7 @@ def test_confirm_prompt_curses(monkeypatch):
             def addnstr(self, *args, **kwargs):
                 pass
 
-            def refresh(self):
+            def noutrefresh(self):
                 pass
 
             def getch(self):
@@ -117,6 +124,7 @@ def test_confirm_prompt_curses(monkeypatch):
     monkeypatch.setattr(cli.curses, "wrapper", fake_wrapper)
     monkeypatch.setattr(cli.curses, "curs_set", lambda n: None)
     monkeypatch.setattr(cli.curses, "newwin", fake_newwin)
+    monkeypatch.setattr(cli.curses, "doupdate", lambda: None)
 
     assert cli.confirm("Sure?") is True
     assert cli.confirm("Sure?") is False
@@ -144,7 +152,7 @@ def test_scroll_menu_handles_curses_error(monkeypatch):
             def erase(self):
                 pass
 
-            def refresh(self):
+            def noutrefresh(self):
                 pass
 
             def keypad(self, flag):
@@ -162,6 +170,7 @@ def test_scroll_menu_handles_curses_error(monkeypatch):
     monkeypatch.setattr(cli.curses, "wrapper", fake_wrapper)
     monkeypatch.setattr(cli.curses, "curs_set", lambda n: None)
     monkeypatch.setattr(cli.curses, "newwin", lambda *args, **kwargs: fake_wrapper(lambda w: w))
+    monkeypatch.setattr(cli.curses, "doupdate", lambda: None)
 
     index = cli.scroll_menu(["A", "B"], 0, header="hdr")
     assert index == 0
@@ -182,7 +191,7 @@ def test_scroll_menu_quits_on_q(monkeypatch):
             def erase(self):
                 pass
 
-            def refresh(self):
+            def noutrefresh(self):
                 pass
 
             def keypad(self, flag):
@@ -199,6 +208,7 @@ def test_scroll_menu_quits_on_q(monkeypatch):
     monkeypatch.setattr(cli.curses, "wrapper", fake_wrapper)
     monkeypatch.setattr(cli.curses, "curs_set", lambda n: None)
     monkeypatch.setattr(cli.curses, "newwin", lambda *args, **kwargs: fake_wrapper(lambda w: w))
+    monkeypatch.setattr(cli.curses, "doupdate", lambda: None)
 
     index = cli.scroll_menu(["A", "B"], 0)
     assert index is None
@@ -217,6 +227,9 @@ def test_boxed_scroll_menu_respects_arrow_keys(monkeypatch):
             def keypad(self, flag):
                 pass
 
+            def noutrefresh(self):
+                pass
+
         return func(FakeStdScr())
 
     class FakeWin:
@@ -231,7 +244,7 @@ def test_boxed_scroll_menu_respects_arrow_keys(monkeypatch):
         def addnstr(self, *args, **kwargs):
             pass
 
-        def refresh(self):
+        def noutrefresh(self):
             pass
 
         def keypad(self, flag):
@@ -249,6 +262,7 @@ def test_boxed_scroll_menu_respects_arrow_keys(monkeypatch):
     monkeypatch.setattr(cli.curses, "wrapper", fake_wrapper)
     monkeypatch.setattr(cli.curses, "curs_set", lambda n: None)
     monkeypatch.setattr(cli.curses, "newwin", fake_newwin)
+    monkeypatch.setattr(cli.curses, "doupdate", lambda: None)
 
     index = cli.scroll_menu(["A", "B"], 0, boxed=True)
     assert index == 1


### PR DESCRIPTION
## Summary
- Use `noutrefresh()`/`doupdate()` in text and confirmation prompts to synchronize overlay drawing
- Replace per-window `refresh()` calls in menu, ledger, and goals views with double-buffered updates
- Adjust unit tests to mock new screen update methods

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68955aba145883288ce583699a79d665