### PR TITLE
Eliminate repeated curses sessions and handle terminal resize

### DIFF
--- a/budget/__main__.py
+++ b/budget/__main__.py
@@ -1,4 +1,21 @@
+"""Module entry point for running the CLI via ``python -m budget``.
+
+Previously this module invoked :func:`budget.cli.main` directly, which
+expected no arguments. After refactoring the application to run under a single
+``curses`` session, :func:`main` now requires the ``stdscr`` window to be
+provided. Using :func:`curses.wrapper` here ensures the correct argument is
+supplied and initializes/tears down the curses session automatically.
+"""
+
+import curses
+
 from .cli import main
 
-if __name__ == "__main__":
-    main()
+
+def entry_point() -> None:
+    """Wrap the CLI ``main`` function in a curses session."""
+    curses.wrapper(main)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution entry
+    entry_point()

--- a/tests/test_goals.py
+++ b/tests/test_goals.py
@@ -12,14 +12,14 @@ def test_add_goal(monkeypatch):
         monkeypatch.setattr(
             cli,
             "goal_form",
-            lambda desc, date, amount, enabled: (
+            lambda stdscr, desc, date, amount, enabled: (
                 "Save",
                 datetime(2023, 1, 1),
                 50.0,
                 True,
             ),
         )
-        cli.add_goal()
+        cli.add_goal(object())
         session = Session()
         goals = session.query(Goal).all()
         assert len(goals) == 1
@@ -36,7 +36,7 @@ def test_add_goal(monkeypatch):
 def test_goal_form_toggle(monkeypatch):
     monkeypatch.setattr(cli, "select", make_prompt(["enabled", "save"]))
     monkeypatch.setattr(cli, "text", make_prompt([]))
-    result = cli.goal_form("Desc", datetime(2023, 1, 1), 10.0, True)
+    result = cli.goal_form(object(), "Desc", datetime(2023, 1, 1), 10.0, True)
     assert result == ("Desc", datetime(2023, 1, 1), 10.0, False)
 
 
@@ -65,7 +65,7 @@ def test_wants_goals_menu_columns(monkeypatch):
 
         captured = {}
 
-        def fake_curses(entries, index, header=None, footer_right=""):
+        def fake_curses(stdscr, entries, index, header=None, footer_right=""):
             captured["entries"] = entries
             captured["index"] = index
             return ("quit", None)
@@ -73,7 +73,7 @@ def test_wants_goals_menu_columns(monkeypatch):
         monkeypatch.setattr(cli, "SessionLocal", Session)
         monkeypatch.setattr(cli, "goals_curses", fake_curses)
 
-        cli.wants_goals_menu()
+        cli.wants_goals_menu(object())
 
         first = captured["entries"][0].split("|")
         assert first[0].strip() == "2023-01-01"

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -139,7 +139,7 @@ def test_ledger_view_displays_all_events(monkeypatch):
 
         captured = {}
 
-        def fake_curses(initial_row, get_prev, get_next, bal_amt):
+        def fake_curses(stdscr, initial_row, get_prev, get_next, bal_amt):
             rows = [initial_row]
             while True:
                 prev = get_prev(rows[0].timestamp)
@@ -162,7 +162,7 @@ def test_ledger_view_displays_all_events(monkeypatch):
         monkeypatch.setattr(cli, "SessionLocal", Session)
         monkeypatch.setattr(cli, "ledger_curses", fake_curses)
 
-        cli.ledger_view()
+        cli.ledger_view(object())
         assert [r.description for r in captured["rows"]] == [
             "Rent",
             "Coffee",

--- a/tests/test_recurring_actions.py
+++ b/tests/test_recurring_actions.py
@@ -25,14 +25,14 @@ def test_delete_recurring(monkeypatch, is_income, amount):
 
         responses = [("delete", 0), None]
 
-        def fake_scroll(entries, index, **kwargs):
+        def fake_scroll(stdscr, entries, index, **kwargs):
             return responses.pop(0)
 
         monkeypatch.setattr(cli, "scroll_menu", fake_scroll)
         monkeypatch.setattr(cli, "SessionLocal", Session)
-        monkeypatch.setattr(cli, "confirm", lambda msg: True)
+        monkeypatch.setattr(cli, "confirm", lambda stdscr, msg: True)
 
-        cli.edit_recurring(is_income)
+        cli.edit_recurring(object(), is_income)
 
         session = Session()
         assert session.query(Recurring).count() == 0


### PR DESCRIPTION
## Summary
- Refactor CLI to run under a single `curses` session and pass `stdscr` through UI helpers
- Add resize handling with `KEY_RESIZE` across scrollable views to avoid flicker
- Update tests for new function signatures

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895610ef4f08328afdca2c7a9cf7939