### PR TITLE
Fix monthly recurring events skipping next month

### DIFF
--- a/budget/cli.py
+++ b/budget/cli.py
@@ -506,7 +506,24 @@ def retreat_date(d: date, freq: str) -> date:
 
 
 def months_between(start: date, end: date) -> int:
-    return (end.year - start.year) * 12 + (end.month - start.month)
+    """Return the number of whole months between ``start`` and ``end``.
+
+    ``months_between`` previously ignored the day component of the dates.
+    This meant that when calculating the next occurrence of a monthly
+    recurring item, any date in the next month would be treated as a full
+    month apart even if it fell *before* the recurring day. For example,
+    looking for the next occurrence after ``2025-09-09`` for an event that
+    starts on ``2025-08-16`` incorrectly skipped September and returned
+    October.
+
+    By subtracting one month when the end day is before the start day we
+    ensure only complete months are counted, preventing skipped months.
+    """
+
+    months = (end.year - start.year) * 12 + (end.month - start.month)
+    if end.day < start.day:
+        months -= 1
+    return months
 
 
 def occurrence_on_or_before(start: date, freq: str, target: date) -> date | None:

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -276,6 +276,34 @@ def test_next_event_handles_multiple_recurring():
         path.unlink()
 
 
+def test_next_event_monthly_does_not_skip_month():
+    """Monthly recurring items are not skipped when querying mid-month."""
+
+    Session, path = get_temp_session()
+    try:
+        session = Session()
+        session.add(
+            Recurring(
+                description="Car Insurance",
+                amount=-100.0,
+                start_date=datetime(2023, 8, 16),
+                frequency="monthly",
+            )
+        )
+        session.commit()
+
+        txns = []
+        recs = session.query(Recurring).all()
+
+        # Looking for the next event after a date early in the following month
+        # should still return the same month's occurrence (September 16th).
+        ev = cli.next_event(datetime(2023, 9, 9), txns, recs)
+        assert ev[0].date() == date(2023, 9, 16)
+    finally:
+        session.close()
+        path.unlink()
+
+
 def test_ledger_view_handles_multiple_recurring(monkeypatch):
     Session, path = get_temp_session()
     try:


### PR DESCRIPTION
## Summary
- adjust `months_between` to only count full months and avoid skipping upcoming monthly occurrences
- add regression test ensuring `next_event` returns the next month's event when querying mid-month

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68957474a77083289cc40688efafe3dc