### PR TITLE
Fix monthly recurrence scheduling

### DIFF
--- a/budget/cli.py
+++ b/budget/cli.py
@@ -552,7 +552,13 @@ def occurrence_after(start: date, freq: str, after: date) -> date | None:
     step = step_map.get(freq)
     if step:
         months = months_between(start, after)
-        months = ((months // step) + 1) * step
+        # round down to the nearest step interval
+        months = (months // step) * step
+        occ = add_months(start, months)
+        # if the computed occurrence is not strictly after the target date,
+        # advance by one additional interval
+        if occ <= after:
+            months += step
         return add_months(start, months)
     return None
 

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -276,6 +276,28 @@ def test_next_event_handles_multiple_recurring():
         path.unlink()
 
 
+def test_next_event_monthly_mid_month():
+    """Monthly recurring events occurring mid-month are not skipped."""
+    Session, path = get_temp_session()
+    try:
+        session = Session()
+        session.add(
+            Recurring(
+                description="HP Instant Ink",
+                amount=-10.0,
+                start_date=datetime(2025, 7, 8),
+                frequency="monthly",
+            )
+        )
+        session.commit()
+        recs = session.query(Recurring).all()
+        ev = cli.next_event(datetime(2025, 9, 1), [], recs)
+        assert ev[0].date() == date(2025, 9, 8)
+    finally:
+        session.close()
+        path.unlink()
+
+
 def test_ledger_view_handles_multiple_recurring(monkeypatch):
     Session, path = get_temp_session()
     try:


### PR DESCRIPTION
## Summary
- correct monthly recurrence calculations so mid-month items propagate to next month
- add regression test to ensure mid-month monthly recurrences are not skipped

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68957474a77083289cc40688efafe3dc