### PR TITLE
Add Account model and default account groundwork

### DIFF
--- a/budget/database.py
+++ b/budget/database.py
@@ -17,21 +17,59 @@ Base = declarative_base()
 
 def init_db() -> None:
     """Create database tables if they do not exist."""
+    from . import models  # noqa: F401
     insp = inspect(engine)
-    required = {"transactions", "balance", "recurring", "goals"}
+    required = {"accounts", "transactions", "balance", "recurring", "goals"}
     existing = set(insp.get_table_names())
     if not required.issubset(existing):
         Base.metadata.create_all(engine)
         existing = set(insp.get_table_names())
 
-    # Ensure legacy databases gain the new balance timestamp column
-    if "balance" in existing:
-        with engine.begin() as conn:
-            cols = [row[1] for row in conn.execute(text("PRAGMA table_info(balance)"))]
-            if "timestamp" not in cols:
+    with engine.begin() as conn:
+        # Ensure default account exists and capture its id
+        res = conn.execute(text("SELECT id FROM accounts WHERE name='Default'"))
+        row = res.fetchone()
+        if row is None:
+            conn.execute(
+                text(
+                    "INSERT INTO accounts (id, name, type) VALUES (1, 'Default', 'checking')"
+                )
+            )
+            default_id = 1
+        else:
+            default_id = row[0]
+
+        # Ensure account_id columns exist and backfill
+        for table in ["transactions", "balance", "recurring", "goals"]:
+            cols = [r[1] for r in conn.execute(text(f"PRAGMA table_info({table})"))]
+            if table == "balance" and "timestamp" not in cols:
                 conn.execute(text("ALTER TABLE balance ADD COLUMN timestamp DATETIME"))
                 conn.execute(
                     text(
                         "UPDATE balance SET timestamp = CURRENT_TIMESTAMP WHERE timestamp IS NULL"
+                    )
+                )
+                cols.append("timestamp")
+
+            if "account_id" not in cols:
+                conn.execute(
+                    text(
+                        f"ALTER TABLE {table} ADD COLUMN account_id INTEGER DEFAULT {default_id}"
+                    )
+                )
+            conn.execute(
+                text(
+                    f"UPDATE {table} SET account_id = {default_id} WHERE account_id IS NULL"
+                )
+            )
+            conn.execute(
+                text(
+                    f"CREATE INDEX IF NOT EXISTS ix_{table}_account_id ON {table}(account_id)"
+                )
+            )
+            if table in {"transactions", "balance"} and "timestamp" in cols:
+                conn.execute(
+                    text(
+                        f"CREATE INDEX IF NOT EXISTS ix_{table}_account_id_timestamp ON {table}(account_id, timestamp)"
                     )
                 )

--- a/budget/models.py
+++ b/budget/models.py
@@ -1,7 +1,30 @@
 from datetime import datetime
-from sqlalchemy import Column, Integer, String, Float, DateTime, Boolean
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    Float,
+    DateTime,
+    Boolean,
+    ForeignKey,
+)
 
 from .database import Base
+
+
+class Account(Base):
+    """Bank or cash account used for financial records."""
+
+    __tablename__ = "accounts"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False, unique=True)
+    type = Column(String, nullable=False, default="checking")
+    institution = Column(String)
+    last4 = Column(String(8))
+    currency = Column(String(3), default="USD")
+    created_at = Column(DateTime, default=datetime.utcnow)
+    archived = Column(Boolean, default=False)
 
 
 class Transaction(Base):
@@ -13,6 +36,13 @@ class Transaction(Base):
     description = Column(String, nullable=False)
     amount = Column(Float, nullable=False)
     timestamp = Column(DateTime, default=datetime.utcnow)
+    account_id = Column(
+        Integer,
+        ForeignKey("accounts.id"),
+        index=True,
+        nullable=False,
+        default=1,
+    )
 
 
 class Balance(Base):
@@ -23,6 +53,13 @@ class Balance(Base):
     id = Column(Integer, primary_key=True, default=1)
     amount = Column(Float, nullable=False, default=0.0)
     timestamp = Column(DateTime, default=datetime.utcnow)
+    account_id = Column(
+        Integer,
+        ForeignKey("accounts.id"),
+        index=True,
+        nullable=False,
+        default=1,
+    )
 
 
 class Recurring(Base):
@@ -35,6 +72,13 @@ class Recurring(Base):
     amount = Column(Float, nullable=False)
     start_date = Column(DateTime, nullable=False)
     frequency = Column(String, nullable=False)
+    account_id = Column(
+        Integer,
+        ForeignKey("accounts.id"),
+        index=True,
+        nullable=False,
+        default=1,
+    )
 
 
 class Goal(Base):
@@ -47,3 +91,10 @@ class Goal(Base):
     amount = Column(Float, nullable=False)
     target_date = Column(DateTime, nullable=False)
     enabled = Column(Boolean, nullable=False, default=True)
+    account_id = Column(
+        Integer,
+        ForeignKey("accounts.id"),
+        index=True,
+        nullable=False,
+        default=1,
+    )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,7 +3,7 @@ import sys
 import tempfile
 from pathlib import Path
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
 # Ensure the project root is on the Python path
@@ -18,6 +18,12 @@ def get_temp_session():
     engine = create_engine(f"sqlite:///{db_path}", future=True)
     TestingSession = sessionmaker(bind=engine)
     database.Base.metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO accounts (id, name, type) VALUES (1, 'Default', 'checking')"
+            )
+        )
     return TestingSession, Path(db_path)
 
 

--- a/tests/test_account_isolation.py
+++ b/tests/test_account_isolation.py
@@ -1,0 +1,26 @@
+from tests.helpers import get_temp_session
+from budget.models import Account, Transaction
+
+
+def test_account_isolation():
+    Session, path = get_temp_session()
+    try:
+        session = Session()
+        default = session.query(Account).filter_by(name="Default").one()
+        secondary = Account(name="Secondary")
+        session.add(secondary)
+        session.commit()
+        session.add_all(
+            [
+                Transaction(description="D", amount=1.0, account_id=default.id),
+                Transaction(description="S", amount=2.0, account_id=secondary.id),
+            ]
+        )
+        session.commit()
+        default_cnt = session.query(Transaction).filter_by(account_id=default.id).count()
+        secondary_cnt = session.query(Transaction).filter_by(account_id=secondary.id).count()
+        assert default_cnt == 1
+        assert secondary_cnt == 1
+    finally:
+        session.close()
+        path.unlink()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,6 +1,6 @@
 from sqlalchemy import create_engine, text
 
-from tests import helpers  # ensures project root on path
+from tests import helpers  # noqa: F401  # ensures project root on path
 from budget import database
 
 

--- a/tests/test_ui_components.py
+++ b/tests/test_ui_components.py
@@ -1,6 +1,6 @@
-import pytest
+import pytest  # noqa: F401
 
-from tests import helpers  # ensures project root on sys.path
+from tests import helpers  # noqa: F401  # ensures project root on sys.path
 from budget import cli
 
 


### PR DESCRIPTION
## Summary
- add `Account` table and thread `account_id` through transactions, balances, recurrings, and goals
- populate and reference a Default account while adding missing columns and indexes in `init_db`
- provide helper/test for multi-account isolation

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68957fb46964832887901121122472a4