### PR TITLE
Display recurrence period column for bills and income lists

### DIFF
--- a/budget/cli.py
+++ b/budget/cli.py
@@ -365,9 +365,10 @@ def edit_recurring(stdscr, is_income: bool) -> None:
             .all()
         )
         desc_w = max((len(r.description) for r in recs), default=0)
+        freq_w = max((len(r.frequency) for r in recs), default=0)
         amt_w = max((len(f"{r.amount:.2f}") for r in recs), default=0)
         entries = [
-            f"{r.start_date.strftime('%Y-%m-%d')} | {r.description:<{desc_w}} | {r.amount:>{amt_w}.2f}"
+            f"{r.start_date.strftime('%Y-%m-%d')} | {r.description:<{desc_w}} | {r.frequency:<{freq_w}} | {r.amount:>{amt_w}.2f}"
             for r in recs
         ]
         entries.append("Back")

--- a/tests/test_recurring_actions.py
+++ b/tests/test_recurring_actions.py
@@ -39,3 +39,39 @@ def test_delete_recurring(monkeypatch, is_income, amount):
     finally:
         session.close()
         path.unlink()
+
+
+@pytest.mark.parametrize(
+    "is_income, amount, frequency",
+    [(False, -10.0, "monthly"), (True, 10.0, "weekly")],
+)
+def test_list_recurring_includes_frequency(monkeypatch, is_income, amount, frequency):
+    Session, path = get_temp_session()
+    try:
+        session = Session()
+        session.add(
+            Recurring(
+                description="R",
+                amount=amount,
+                start_date=datetime(2023, 1, 1),
+                frequency=frequency,
+            )
+        )
+        session.commit()
+        session.close()
+
+        captured = []
+
+        def fake_scroll(stdscr, entries, index, **kwargs):
+            captured.extend(entries)
+            return None
+
+        monkeypatch.setattr(cli, "scroll_menu", fake_scroll)
+        monkeypatch.setattr(cli, "SessionLocal", Session)
+
+        cli.edit_recurring(object(), is_income)
+
+        assert any(frequency in entry for entry in captured[:-1])
+    finally:
+        session.close()
+        path.unlink()


### PR DESCRIPTION
## Summary
- show recurrence frequency column when listing recurring bills or income
- test that frequency is included in recurring item listings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68961438a3b483288b9c898b0b471006