### PR TITLE
Add irregular transaction models and migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ python -m budget
 ```
 
 Transactions are stored in a local SQLite database (`transactions.db`).
+
+## Recurrence rules
+
+Semi-monthly frequency is interpreted as events on the 1st and 15th of each month (clamped if the month is shorter).

--- a/budget/cli.py
+++ b/budget/cli.py
@@ -788,13 +788,14 @@ def ledger_rows(session):
         quantile=IRREG_QUANTILE,
     )
     for d, amt in irr_series:
-        txns.append(
-            Transaction(
-                description="Irregular",
-                amount=-amt,
-                timestamp=datetime.combine(d, datetime.min.time()),
+        if amt:
+            txns.append(
+                Transaction(
+                    description="Irregular",
+                    amount=-amt,
+                    timestamp=datetime.combine(d, datetime.min.time()),
+                )
             )
-        )
     txns.sort(key=lambda t: t.timestamp)
 
     def total_up_to(ts: datetime) -> float:
@@ -845,7 +846,12 @@ def ledger_curses(stdscr, initial_row, get_prev, get_next, bal_amt):
         desc_w = len(initial_row.description)
         amt_w = len(f"{initial_row.amount:.2f}")
         run_w = len(f"{initial_row.running:.2f}")
-        footer_left = date.today().isoformat()
+        mode_label = (
+            "Deterministic"
+            if IRREG_MODE == "deterministic"
+            else f"MC {IRREG_QUANTILE.upper()}"
+        )
+        footer_left = f"Irregular forecast: {mode_label}"
 
         while True:
             h, w = stdscr.getmaxyx()
@@ -1114,13 +1120,14 @@ def ledger_view(stdscr) -> None:
         quantile=IRREG_QUANTILE,
     )
     for d, amt in irr_series:
-        txns.append(
-            Transaction(
-                description="Irregular",
-                amount=-amt,
-                timestamp=datetime.combine(d, datetime.min.time()),
+        if amt:
+            txns.append(
+                Transaction(
+                    description="Irregular",
+                    amount=-amt,
+                    timestamp=datetime.combine(d, datetime.min.time()),
+                )
             )
-        )
     txns.sort(key=lambda t: t.timestamp)
 
     today = date.today()

--- a/budget/database.py
+++ b/budget/database.py
@@ -27,6 +27,7 @@ def init_db() -> None:
         "goals",
         "irregular_categories",
         "irregular_state",
+        "irregular_rules",
     }
     existing = set(insp.get_table_names())
     if not required.issubset(existing):
@@ -185,5 +186,29 @@ def init_db() -> None:
         conn.execute(
             text(
                 "CREATE UNIQUE INDEX IF NOT EXISTS ix_irregular_state_category_id ON irregular_state(category_id)"
+            )
+        )
+
+        # Ensure irregular rules columns and indexes
+        cols = [r[1] for r in conn.execute(text("PRAGMA table_info(irregular_rules)"))]
+        if "category_id" not in cols:
+            conn.execute(
+                text(
+                    "ALTER TABLE irregular_rules ADD COLUMN category_id INTEGER REFERENCES irregular_categories(id)"
+                )
+            )
+        if "pattern" not in cols:
+            conn.execute(
+                text("ALTER TABLE irregular_rules ADD COLUMN pattern TEXT")
+            )
+        if "active" not in cols:
+            conn.execute(
+                text(
+                    "ALTER TABLE irregular_rules ADD COLUMN active BOOLEAN DEFAULT 1"
+                )
+            )
+        conn.execute(
+            text(
+                "CREATE INDEX IF NOT EXISTS ix_irregular_rules_category_pattern ON irregular_rules(category_id, pattern)"
             )
         )

--- a/budget/models.py
+++ b/budget/models.py
@@ -7,7 +7,10 @@ from sqlalchemy import (
     DateTime,
     Boolean,
     ForeignKey,
+    Text,
+    Index,
 )
+from sqlalchemy.orm import relationship
 
 from .database import Base
 
@@ -97,4 +100,60 @@ class Goal(Base):
         index=True,
         nullable=False,
         default=1,
+    )
+
+
+class IrregularCategory(Base):
+    """Category tracking irregular transactions (e.g. car repairs)."""
+
+    __tablename__ = "irregular_categories"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False, unique=True)
+    active = Column(Boolean, default=True)
+    window_days = Column(Integer, default=120)
+    alpha = Column(Float, default=0.3)
+    safety_quantile = Column(Float, default=0.8)
+    account_id = Column(Integer, ForeignKey("accounts.id"), nullable=True, index=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    state = relationship(
+        "IrregularState",
+        uselist=False,
+        back_populates="category",
+        cascade="all, delete-orphan",
+    )
+
+    __table_args__ = (Index("ix_irregular_categories_name", "name"),)
+
+    def __init__(self, **kwargs):
+        if "state" not in kwargs:
+            kwargs["state"] = IrregularState()
+        super().__init__(**kwargs)
+
+
+class IrregularState(Base):
+    """Learned state about an irregular category."""
+
+    __tablename__ = "irregular_state"
+
+    id = Column(Integer, primary_key=True)
+    category_id = Column(
+        Integer,
+        ForeignKey("irregular_categories.id"),
+        nullable=False,
+    )
+    avg_gap_days = Column(Float)
+    weekday_probs = Column(Text)
+    amount_mu = Column(Float)
+    amount_sigma = Column(Float)
+    median_amount = Column(Float)
+    last_event_at = Column(DateTime)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    category = relationship("IrregularCategory", back_populates="state")
+
+    __table_args__ = (
+        Index("ix_irregular_state_category_id", "category_id", unique=True),
     )

--- a/budget/models.py
+++ b/budget/models.py
@@ -157,3 +157,22 @@ class IrregularState(Base):
     __table_args__ = (
         Index("ix_irregular_state_category_id", "category_id", unique=True),
     )
+
+
+class IrregularRule(Base):
+    """Simple substring rule for mapping transactions to irregular categories."""
+
+    __tablename__ = "irregular_rules"
+
+    id = Column(Integer, primary_key=True)
+    category_id = Column(
+        Integer, ForeignKey("irregular_categories.id"), nullable=False, index=True
+    )
+    pattern = Column(String, nullable=False)
+    active = Column(Boolean, default=True)
+
+    category = relationship("IrregularCategory", backref="rules")
+
+    __table_args__ = (
+        Index("ix_irregular_rules_category_pattern", "category_id", "pattern"),
+    )

--- a/budget/services.py
+++ b/budget/services.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+from datetime import date, datetime, timedelta
+import calendar
+from typing import Iterable, Iterator
+
+
+def add_months(d: date, months: int) -> date:
+    y = d.year + (d.month - 1 + months) // 12
+    m = (d.month - 1 + months) % 12 + 1
+    day = min(d.day, calendar.monthrange(y, m)[1])
+    return date(y, m, day)
+
+
+def month_diff(a: date, b: date) -> int:
+    # whole months a->b; negative if b<a
+    md = (b.year - a.year) * 12 + (b.month - a.month)
+    if b.day < a.day:
+        md -= 1
+    return md
+
+
+def weekly_series(anchor: date, start: date, end: date, step_days: int) -> Iterator[date]:
+    # step_days=7 for weekly, 14 for biweekly
+    k = max(0, (start - anchor).days // step_days)
+    d = anchor + timedelta(days=k * step_days)
+    if d < start:
+        d += timedelta(days=step_days)
+    while d <= end:
+        yield d
+        d += timedelta(days=step_days)
+
+
+def monthly_series(anchor: date, start: date, end: date, step_months: int) -> Iterator[date]:
+    k = max(0, month_diff(anchor, start))
+    d = add_months(anchor, k)
+    # ensure d >= start respecting day-of-month rule
+    while d < start:
+        k += 1
+        d = add_months(anchor, k)
+    while d <= end:
+        yield d
+        k += step_months
+        d = add_months(anchor, k)
+
+
+def semi_monthly_series(anchor: date, start: date, end: date) -> Iterator[date]:
+    """
+    Definition: 1st and 15th of each month (clamped if month shorter).
+    If you prefer anchor & anchor+15, switch logic accordingly.
+    """
+    # iterate months covering the window
+    first_month = date(start.year, start.month, 1)
+    d = first_month
+    while d <= end:
+        last = calendar.monthrange(d.year, d.month)[1]
+        for day in (1, min(15, last)):
+            occ = date(d.year, d.month, day)
+            if start <= occ <= end:
+                yield occ
+        d = add_months(d, 1)
+
+
+def occurrences_between(anchor: date, frequency: str, start: date, end: date) -> list[date]:
+    freq = frequency.strip().lower()
+    if start > end:
+        return []
+    if freq == "weekly":
+        it = weekly_series(anchor, start, end, 7)
+    elif freq == "biweekly":
+        it = weekly_series(anchor, start, end, 14)
+    elif freq == "monthly":
+        it = monthly_series(anchor, start, end, 1)
+    elif freq == "quarterly":
+        it = monthly_series(anchor, start, end, 3)
+    elif freq == "semi annually":
+        it = monthly_series(anchor, start, end, 6)
+    elif freq == "annually":
+        it = monthly_series(anchor, start, end, 12)
+    elif freq == "semi monthly":
+        it = semi_monthly_series(anchor, start, end)
+    else:
+        # unknown frequency: return nothing
+        return []
+    return list(it)

--- a/budget/services_irregular.py
+++ b/budget/services_irregular.py
@@ -429,7 +429,18 @@ def irregular_daily_series(
     return sorted(totals.items(), key=lambda x: x[0])
 
 
-def categories(session: Session) -> list[IrregularCategory]: ...
+def categories(session: Session) -> list[IrregularCategory]:
+    """Return irregular categories ordered by name.
+
+    All categories are returned so the caller can inspect or toggle the
+    ``active`` flag as needed.
+    """
+
+    return (
+        session.query(IrregularCategory)
+        .order_by(IrregularCategory.name)
+        .all()
+    )
 
 
 def rules_for(session: Session, category_id: int) -> list[str]:

--- a/budget/services_irregular.py
+++ b/budget/services_irregular.py
@@ -415,7 +415,10 @@ def irregular_daily_series(
         .filter(IrregularCategory.active.is_(True))
         .all()
     )
-    totals: dict[date, float] = {}
+    horizon = (end - start).days + 1
+    totals: dict[date, float] = {
+        start + timedelta(days=i): 0.0 for i in range(horizon)
+    }
     for cat in cats:
         forecast = forecast_irregular(session, cat.id, start, end, mode=mode)
         series: Iterable[tuple[date, float]]
@@ -424,8 +427,8 @@ def irregular_daily_series(
         else:
             series = forecast  # type: ignore[assignment]
         for d, amt in series:
-            if amt:
-                totals[d] = totals.get(d, 0.0) + amt
+            if start <= d <= end and amt:
+                totals[d] += amt
     return sorted(totals.items(), key=lambda x: x[0])
 
 

--- a/budget/services_irregular.py
+++ b/budget/services_irregular.py
@@ -3,7 +3,7 @@ from typing import Iterable, Literal
 
 from sqlalchemy.orm import Session
 
-from .models import IrregularCategory, IrregularState
+from .models import IrregularCategory, IrregularState, IrregularRule
 
 
 def ensure_category(session: Session, name: str, **kwargs) -> IrregularCategory: ...
@@ -27,3 +27,33 @@ def forecast_irregular(
 ): ...
 
 def categories(session: Session) -> list[IrregularCategory]: ...
+
+
+def rules_for(session: Session, category_id: int) -> list[str]:
+    """Return active rule patterns for the given category."""
+
+    rows = (
+        session.query(IrregularRule.pattern)
+        .filter(
+            IrregularRule.category_id == category_id, IrregularRule.active.is_(True)
+        )
+        .all()
+    )
+    return [r[0] for r in rows]
+
+
+def match_category_id(session: Session, description: str) -> int | None:
+    """Return the first matching active category for the description."""
+
+    desc = description.lower()
+    rules = (
+        session.query(IrregularRule)
+        .join(IrregularCategory, IrregularRule.category_id == IrregularCategory.id)
+        .filter(IrregularRule.active.is_(True), IrregularCategory.active.is_(True))
+        .order_by(IrregularRule.id)
+        .all()
+    )
+    for rule in rules:
+        if rule.pattern.lower() in desc:
+            return rule.category_id
+    return None

--- a/budget/services_irregular.py
+++ b/budget/services_irregular.py
@@ -1,0 +1,29 @@
+from datetime import date, datetime
+from typing import Iterable, Literal
+
+from sqlalchemy.orm import Session
+
+from .models import IrregularCategory, IrregularState
+
+
+def ensure_category(session: Session, name: str, **kwargs) -> IrregularCategory: ...
+
+def get_or_create_state(session: Session, category_id: int) -> IrregularState: ...
+
+def learn_irregular_state(
+    session: Session,
+    category_id: int,
+    start: date | datetime,
+    end: date | datetime,
+) -> IrregularState: ...
+
+def forecast_irregular(
+    session: Session,
+    category_id: int,
+    start: date,
+    end: date,
+    mode: Literal["deterministic", "monte_carlo"] = "deterministic",
+    n: int = 500,
+): ...
+
+def categories(session: Session) -> list[IrregularCategory]: ...

--- a/budget/services_irregular.py
+++ b/budget/services_irregular.py
@@ -1,9 +1,12 @@
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
+import json
+import math
+from statistics import mean, median, stdev
 from typing import Iterable, Literal
 
 from sqlalchemy.orm import Session
 
-from .models import IrregularCategory, IrregularState, IrregularRule
+from .models import IrregularCategory, IrregularState, IrregularRule, Transaction
 
 
 def ensure_category(session: Session, name: str, **kwargs) -> IrregularCategory: ...
@@ -15,7 +18,115 @@ def learn_irregular_state(
     category_id: int,
     start: date | datetime,
     end: date | datetime,
-) -> IrregularState: ...
+) -> IrregularState:
+    """Learn timing and amount stats for an irregular category.
+
+    Parameters
+    ----------
+    session : Session
+        Database session.
+    category_id : int
+        Target irregular category.
+    start, end : date | datetime
+        Period to learn from. The start date will be clamped to the
+        category's ``window_days`` ending at ``end``.
+
+    Returns
+    -------
+    IrregularState
+        The upserted state object for the category.
+    """
+
+    # Fetch category to obtain learning parameters like window_days and alpha
+    category: IrregularCategory | None = session.get(IrregularCategory, category_id)
+    if category is None:
+        raise ValueError(f"Unknown category id {category_id}")
+
+    # Clamp start to the category's window
+    end_dt = end if isinstance(end, datetime) else datetime.combine(end, datetime.min.time())
+    start_dt = (
+        start if isinstance(start, datetime) else datetime.combine(start, datetime.min.time())
+    )
+
+    window_start = end_dt - timedelta(days=category.window_days)
+    if start_dt < window_start:
+        start_dt = window_start
+
+    # Fetch or create state row
+    state = (
+        session.query(IrregularState)
+        .filter(IrregularState.category_id == category_id)
+        .one_or_none()
+    )
+    if state is None:
+        state = IrregularState(category_id=category_id)
+        session.add(state)
+
+    # Fetch transactions in window and matching category rules
+    txns = (
+        session.query(Transaction)
+        .filter(
+            Transaction.timestamp >= start_dt,
+            Transaction.timestamp <= end_dt,
+        )
+        .order_by(Transaction.timestamp)
+        .all()
+    )
+    txns = [t for t in txns if match_category_id(session, t.description) == category_id]
+
+    if not txns:
+        session.commit()
+        return state
+
+    amounts = [abs(t.amount) for t in txns if abs(t.amount) > 0]
+    median_amount = median(amounts) if amounts else None
+    last_event_at = max(t.timestamp for t in txns)
+
+    # If fewer than 3 transactions, only update last_event_at and median_amount
+    if len(txns) < 3:
+        state.median_amount = median_amount
+        state.last_event_at = last_event_at
+        session.add(state)
+        session.commit()
+        return state
+
+    timestamps = [t.timestamp for t in txns]
+    gaps = [
+        (timestamps[i] - timestamps[i - 1]).total_seconds() / 86400.0
+        for i in range(1, len(timestamps))
+    ]
+
+    if len(gaps) >= 3:
+        avg_gap = gaps[0]
+        for g in gaps[1:]:
+            avg_gap = category.alpha * g + (1 - category.alpha) * avg_gap
+    else:
+        avg_gap = mean(gaps)
+
+    counts = [1] * 7
+    for t in txns:
+        counts[t.timestamp.weekday()] += 1
+    total = sum(counts)
+    weekday_probs = [c / total for c in counts]
+
+    if len(amounts) >= 8:
+        logs = [math.log(a) for a in amounts if a > 0]
+        mu = mean(logs)
+        sigma = stdev(logs) if len(logs) > 1 else 0.0
+        state.amount_mu = mu
+        state.amount_sigma = sigma
+    else:
+        state.amount_mu = None
+        state.amount_sigma = None
+
+    state.avg_gap_days = avg_gap
+    state.weekday_probs = json.dumps(weekday_probs)
+    state.median_amount = median_amount
+    state.last_event_at = last_event_at
+
+    session.add(state)
+    session.commit()
+    return state
 
 def forecast_irregular(
     session: Session,

--- a/tests/test_irregular.py
+++ b/tests/test_irregular.py
@@ -1,0 +1,168 @@
+from tests import helpers  # noqa: F401  # ensure project root on path
+
+from datetime import date, datetime, timedelta
+import itertools
+import json
+import math
+import random
+
+from budget import cli
+from budget.models import IrregularCategory, IrregularRule, Transaction
+from budget.services_irregular import (
+    learn_irregular_state,
+    forecast_irregular,
+    irregular_daily_series,
+)
+
+
+def test_learn_state_minimum():
+    TestingSession, db_path = helpers.get_temp_session()
+    session = TestingSession()
+
+    cat = IrregularCategory(name="Groceries")
+    session.add(cat)
+    session.commit()
+    session.add(IrregularRule(category_id=cat.id, pattern="walmart"))
+    session.commit()
+
+    random.seed(0)
+    ts = datetime(2024, 1, 1)
+    txns = []
+    for i in range(10):
+        txns.append(
+            Transaction(
+                description="Walmart Supercenter",
+                amount=-50.0 - i,
+                timestamp=ts,
+            )
+        )
+        ts += timedelta(days=random.randint(3, 7))
+    session.add_all(txns)
+    session.commit()
+
+    start = txns[0].timestamp.date()
+    end = txns[-1].timestamp.date()
+    state = learn_irregular_state(session, cat.id, start, end)
+
+    assert 3 <= (state.avg_gap_days or 0) <= 8
+    assert (state.median_amount or 0) > 0
+    probs = json.loads(state.weekday_probs)
+    assert len(probs) == 7
+    assert all(p > 0 for p in probs)
+    assert math.isclose(sum(probs), 1.0, rel_tol=1e-9)
+
+    session.close()
+    db_path.unlink()
+
+
+def test_forecast_deterministic():
+    TestingSession, db_path = helpers.get_temp_session()
+    session = TestingSession()
+
+    cat = IrregularCategory(name="Groceries")
+    session.add(cat)
+    session.commit()
+
+    state = cat.state
+    state.avg_gap_days = 7
+    state.median_amount = 40.0
+    state.last_event_at = datetime(2024, 1, 1)
+    session.add(state)
+    session.commit()
+
+    start = date(2024, 1, 2)
+    end = start + timedelta(days=59)
+    forecast = forecast_irregular(session, cat.id, start, end, mode="deterministic")
+
+    horizon = (end - start).days + 1
+    events = {d: amt for d, amt in forecast}
+    series = [events.get(start + timedelta(days=i), 0.0) for i in range(horizon)]
+
+    assert len(series) == horizon
+    assert sum(series) > 0
+
+    session.close()
+    db_path.unlink()
+
+
+def test_forecast_mc_quantiles():
+    TestingSession, db_path = helpers.get_temp_session()
+    session = TestingSession()
+
+    cat = IrregularCategory(name="Groceries")
+    session.add(cat)
+    session.commit()
+
+    state = cat.state
+    state.avg_gap_days = 7
+    state.median_amount = 40.0
+    state.last_event_at = datetime(2024, 1, 1)
+    state.amount_mu = math.log(40.0)
+    state.amount_sigma = 0.1
+    session.add(state)
+    session.commit()
+
+    start = date(2024, 1, 2)
+    end = start + timedelta(days=59)
+    random.seed(0)
+    forecast = forecast_irregular(
+        session, cat.id, start, end, mode="monte_carlo", n=100
+    )
+
+    horizon = (end - start).days + 1
+    assert len(forecast["p50"]) == len(forecast["p80"]) == horizon
+
+    total_p50 = total_p80 = 0.0
+    for i in range(horizon):
+        d_expected = start + timedelta(days=i)
+        d50, v50 = forecast["p50"][i]
+        d80, v80 = forecast["p80"][i]
+        assert d50 == d80 == d_expected
+        assert v80 >= v50
+        total_p50 += v50
+        total_p80 += v80
+    assert total_p80 >= total_p50 >= 0
+
+    session.close()
+    db_path.unlink()
+
+
+def test_merge_into_ledger(monkeypatch):
+    TestingSession, db_path = helpers.get_temp_session()
+    session = TestingSession()
+
+    fixed_today = date(2024, 1, 1)
+
+    class FakeDate(date):
+        @classmethod
+        def today(cls):
+            return fixed_today
+
+    monkeypatch.setattr(cli, "date", FakeDate)
+    monkeypatch.setattr(cli, "IRREG_MODE", "deterministic")
+
+    cat = IrregularCategory(name="Groceries")
+    session.add(cat)
+    session.commit()
+
+    state = cat.state
+    state.avg_gap_days = 7
+    state.median_amount = 40.0
+    state.last_event_at = datetime.combine(
+        fixed_today - timedelta(days=1), datetime.min.time()
+    )
+    session.add(state)
+    session.commit()
+
+    start = fixed_today
+    end = start + timedelta(days=30)
+    forecast = dict(irregular_daily_series(session, start, end))
+
+    rows = list(itertools.islice(cli.ledger_rows(session), len(forecast)))
+    irregular_rows = {(r.date, r.amount) for r in rows if r.description == "Irregular"}
+
+    for d, amt in forecast.items():
+        assert (d, -amt) in irregular_rows
+
+    session.close()
+    db_path.unlink()

--- a/tests/test_irregular_monte_carlo.py
+++ b/tests/test_irregular_monte_carlo.py
@@ -1,0 +1,51 @@
+from tests import helpers  # noqa: F401  # ensure project root on path
+
+from datetime import date, datetime, timedelta
+import json
+import math
+import random
+
+from budget.models import IrregularCategory
+from budget.services_irregular import forecast_irregular
+
+
+def test_forecast_irregular_monte_carlo():
+    TestingSession, db_path = helpers.get_temp_session()
+    session = TestingSession()
+
+    cat = IrregularCategory(name="Auto")
+    session.add(cat)
+    session.commit()
+
+    state = cat.state
+    state.avg_gap_days = 5
+    state.median_amount = 100.0
+    state.last_event_at = datetime(2023, 12, 31)
+    state.weekday_probs = json.dumps([1, 1, 1, 1, 1, 1, 1])
+    state.amount_mu = math.log(100.0)
+    state.amount_sigma = 0.1
+    session.add(state)
+    session.commit()
+
+    start = date(2024, 1, 1)
+    end = date(2024, 1, 31)
+
+    random.seed(0)
+    forecast = forecast_irregular(
+        session, cat.id, start, end, mode="monte_carlo", n=100
+    )
+
+    horizon = (end - start).days + 1
+    assert all(len(forecast[p]) == horizon for p in ("p50", "p80", "p90"))
+    for i in range(horizon):
+        d_expected = start + timedelta(days=i)
+        d50, v50 = forecast["p50"][i]
+        d80, v80 = forecast["p80"][i]
+        d90, v90 = forecast["p90"][i]
+        assert d50 == d80 == d90 == d_expected
+        assert v80 >= v50
+        assert v90 >= v80
+    assert any(v > 0 for _, v in forecast["p90"])
+
+    session.close()
+    db_path.unlink()

--- a/tests/test_irregular_rules.py
+++ b/tests/test_irregular_rules.py
@@ -1,0 +1,31 @@
+from tests import helpers  # noqa: F401  # ensure project root on path
+
+from budget.models import IrregularCategory, IrregularRule
+from budget.services_irregular import rules_for, match_category_id
+
+
+def test_rules_for_and_match_category():
+    TestingSession, db_path = helpers.get_temp_session()
+    session = TestingSession()
+
+    cat1 = IrregularCategory(name="Auto")
+    cat2 = IrregularCategory(name="Health")
+    session.add_all([cat1, cat2])
+    session.commit()
+
+    session.add_all(
+        [
+            IrregularRule(category_id=cat1.id, pattern="auto"),
+            IrregularRule(category_id=cat2.id, pattern="dentist"),
+        ]
+    )
+    session.commit()
+
+    assert rules_for(session, cat1.id) == ["auto"]
+    assert match_category_id(session, "Paid AUTO shop") == cat1.id
+    assert match_category_id(session, "dentist appointment") == cat2.id
+    assert match_category_id(session, "unknown") is None
+
+    session.close()
+    db_path.unlink()
+


### PR DESCRIPTION
## Summary
- add IrregularCategory and IrregularState models with default blank state
- support idempotent migrations for irregular tables
- stub out irregular services API

## Testing
- `pytest -q`
- create irregular category and verify associated blank state

------
https://chatgpt.com/codex/tasks/task_e_68961a57cd108328ac2ebfe542755b6a