### PR TITLE
Add irregular transaction rule mapping

### DIFF
--- a/budget/database.py
+++ b/budget/database.py
@@ -27,6 +27,7 @@ def init_db() -> None:
         "goals",
         "irregular_categories",
         "irregular_state",
+        "irregular_rules",
     }
     existing = set(insp.get_table_names())
     if not required.issubset(existing):
@@ -185,5 +186,29 @@ def init_db() -> None:
         conn.execute(
             text(
                 "CREATE UNIQUE INDEX IF NOT EXISTS ix_irregular_state_category_id ON irregular_state(category_id)"
+            )
+        )
+
+        # Ensure irregular rules columns and indexes
+        cols = [r[1] for r in conn.execute(text("PRAGMA table_info(irregular_rules)"))]
+        if "category_id" not in cols:
+            conn.execute(
+                text(
+                    "ALTER TABLE irregular_rules ADD COLUMN category_id INTEGER REFERENCES irregular_categories(id)"
+                )
+            )
+        if "pattern" not in cols:
+            conn.execute(
+                text("ALTER TABLE irregular_rules ADD COLUMN pattern TEXT")
+            )
+        if "active" not in cols:
+            conn.execute(
+                text(
+                    "ALTER TABLE irregular_rules ADD COLUMN active BOOLEAN DEFAULT 1"
+                )
+            )
+        conn.execute(
+            text(
+                "CREATE INDEX IF NOT EXISTS ix_irregular_rules_category_pattern ON irregular_rules(category_id, pattern)"
             )
         )

--- a/budget/models.py
+++ b/budget/models.py
@@ -157,3 +157,22 @@ class IrregularState(Base):
     __table_args__ = (
         Index("ix_irregular_state_category_id", "category_id", unique=True),
     )
+
+
+class IrregularRule(Base):
+    """Simple substring rule for mapping transactions to irregular categories."""
+
+    __tablename__ = "irregular_rules"
+
+    id = Column(Integer, primary_key=True)
+    category_id = Column(
+        Integer, ForeignKey("irregular_categories.id"), nullable=False, index=True
+    )
+    pattern = Column(String, nullable=False)
+    active = Column(Boolean, default=True)
+
+    category = relationship("IrregularCategory", backref="rules")
+
+    __table_args__ = (
+        Index("ix_irregular_rules_category_pattern", "category_id", "pattern"),
+    )

--- a/budget/services_irregular.py
+++ b/budget/services_irregular.py
@@ -3,7 +3,7 @@ from typing import Iterable, Literal
 
 from sqlalchemy.orm import Session
 
-from .models import IrregularCategory, IrregularState
+from .models import IrregularCategory, IrregularState, IrregularRule
 
 
 def ensure_category(session: Session, name: str, **kwargs) -> IrregularCategory: ...
@@ -27,3 +27,33 @@ def forecast_irregular(
 ): ...
 
 def categories(session: Session) -> list[IrregularCategory]: ...
+
+
+def rules_for(session: Session, category_id: int) -> list[str]:
+    """Return active rule patterns for the given category."""
+
+    rows = (
+        session.query(IrregularRule.pattern)
+        .filter(
+            IrregularRule.category_id == category_id, IrregularRule.active.is_(True)
+        )
+        .all()
+    )
+    return [r[0] for r in rows]
+
+
+def match_category_id(session: Session, description: str) -> int | None:
+    """Return the first matching active category for the description."""
+
+    desc = description.lower()
+    rules = (
+        session.query(IrregularRule)
+        .join(IrregularCategory, IrregularRule.category_id == IrregularCategory.id)
+        .filter(IrregularRule.active.is_(True), IrregularCategory.active.is_(True))
+        .order_by(IrregularRule.id)
+        .all()
+    )
+    for rule in rules:
+        if rule.pattern.lower() in desc:
+            return rule.category_id
+    return None

--- a/tests/test_irregular_rules.py
+++ b/tests/test_irregular_rules.py
@@ -1,0 +1,31 @@
+from tests import helpers  # noqa: F401  # ensure project root on path
+
+from budget.models import IrregularCategory, IrregularRule
+from budget.services_irregular import rules_for, match_category_id
+
+
+def test_rules_for_and_match_category():
+    TestingSession, db_path = helpers.get_temp_session()
+    session = TestingSession()
+
+    cat1 = IrregularCategory(name="Auto")
+    cat2 = IrregularCategory(name="Health")
+    session.add_all([cat1, cat2])
+    session.commit()
+
+    session.add_all(
+        [
+            IrregularRule(category_id=cat1.id, pattern="auto"),
+            IrregularRule(category_id=cat2.id, pattern="dentist"),
+        ]
+    )
+    session.commit()
+
+    assert rules_for(session, cat1.id) == ["auto"]
+    assert match_category_id(session, "Paid AUTO shop") == cat1.id
+    assert match_category_id(session, "dentist appointment") == cat2.id
+    assert match_category_id(session, "unknown") is None
+
+    session.close()
+    db_path.unlink()
+


### PR DESCRIPTION
## Summary
- add `IrregularRule` model for substring-based irregular category matching
- support listing and matching rules
- ensure new table and indexes created during `init_db`
- test rule matching

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68961dc7b0108328a1ebf90eb78e32c6