### PR TITLE
feat: add irregular spending menu

### DIFF
--- a/budget/services_irregular.py
+++ b/budget/services_irregular.py
@@ -429,7 +429,18 @@ def irregular_daily_series(
     return sorted(totals.items(), key=lambda x: x[0])
 
 
-def categories(session: Session) -> list[IrregularCategory]: ...
+def categories(session: Session) -> list[IrregularCategory]:
+    """Return irregular categories ordered by name.
+
+    All categories are returned so the caller can inspect or toggle the
+    ``active`` flag as needed.
+    """
+
+    return (
+        session.query(IrregularCategory)
+        .order_by(IrregularCategory.name)
+        .all()
+    )
 
 
 def rules_for(session: Session, category_id: int) -> list[str]:


### PR DESCRIPTION
## Summary
- add irregular spending manager with category editing, rule management, and learning from history
- introduce irregular forecast mode toggle and in-session setting
- expose irregular categories helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68966beecf588328a9dbc813ca813b44