### PR TITLE
Integrate irregular forecast into ledger totals

### DIFF
--- a/budget/cli.py
+++ b/budget/cli.py
@@ -788,13 +788,14 @@ def ledger_rows(session):
         quantile=IRREG_QUANTILE,
     )
     for d, amt in irr_series:
-        txns.append(
-            Transaction(
-                description="Irregular",
-                amount=-amt,
-                timestamp=datetime.combine(d, datetime.min.time()),
+        if amt:
+            txns.append(
+                Transaction(
+                    description="Irregular",
+                    amount=-amt,
+                    timestamp=datetime.combine(d, datetime.min.time()),
+                )
             )
-        )
     txns.sort(key=lambda t: t.timestamp)
 
     def total_up_to(ts: datetime) -> float:
@@ -845,7 +846,12 @@ def ledger_curses(stdscr, initial_row, get_prev, get_next, bal_amt):
         desc_w = len(initial_row.description)
         amt_w = len(f"{initial_row.amount:.2f}")
         run_w = len(f"{initial_row.running:.2f}")
-        footer_left = date.today().isoformat()
+        mode_label = (
+            "Deterministic"
+            if IRREG_MODE == "deterministic"
+            else f"MC {IRREG_QUANTILE.upper()}"
+        )
+        footer_left = f"Irregular forecast: {mode_label}"
 
         while True:
             h, w = stdscr.getmaxyx()
@@ -1114,13 +1120,14 @@ def ledger_view(stdscr) -> None:
         quantile=IRREG_QUANTILE,
     )
     for d, amt in irr_series:
-        txns.append(
-            Transaction(
-                description="Irregular",
-                amount=-amt,
-                timestamp=datetime.combine(d, datetime.min.time()),
+        if amt:
+            txns.append(
+                Transaction(
+                    description="Irregular",
+                    amount=-amt,
+                    timestamp=datetime.combine(d, datetime.min.time()),
+                )
             )
-        )
     txns.sort(key=lambda t: t.timestamp)
 
     today = date.today()

--- a/budget/services_irregular.py
+++ b/budget/services_irregular.py
@@ -415,7 +415,10 @@ def irregular_daily_series(
         .filter(IrregularCategory.active.is_(True))
         .all()
     )
-    totals: dict[date, float] = {}
+    horizon = (end - start).days + 1
+    totals: dict[date, float] = {
+        start + timedelta(days=i): 0.0 for i in range(horizon)
+    }
     for cat in cats:
         forecast = forecast_irregular(session, cat.id, start, end, mode=mode)
         series: Iterable[tuple[date, float]]
@@ -424,8 +427,8 @@ def irregular_daily_series(
         else:
             series = forecast  # type: ignore[assignment]
         for d, amt in series:
-            if amt:
-                totals[d] = totals.get(d, 0.0) + amt
+            if start <= d <= end and amt:
+                totals[d] += amt
     return sorted(totals.items(), key=lambda x: x[0])
 
 


### PR DESCRIPTION
## Summary
- Aggregate irregular category forecasts per day
- Merge irregular forecast amounts into ledger rows and show forecast mode note

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68966f85be548328b968c20f828d3b1d