### PR TITLE
feat: add per-account balance and account-aware ledger

### DIFF
--- a/budget/cli.py
+++ b/budget/cli.py
@@ -38,6 +38,9 @@ from .services import (
     delete_transfer,
     update_transfer,
     max_safe_payment_today,
+    create_recurring_transfer,
+    update_recurring_transfer,
+    delete_recurring_transfer,
 )
 
 FREQUENCIES = [
@@ -540,38 +543,88 @@ def accounts_menu(stdscr) -> None:
         session.close()
 
 
+def recurring_form(
+    stdscr,
+    session,
+    from_acct: Account,
+    description: str,
+    start: datetime,
+    amount: float,
+    to_acct: Account | None,
+    freq: str,
+):
+    """Interactive form for adding/editing recurring bills/incomes."""
+
+    default = "name"
+    while True:
+        to_label = to_acct.name if to_acct else "Outgoing transaction"
+        choice = select(
+            stdscr,
+            "Select field to edit",
+            choices=[
+                (f"From: {from_acct.name}", "from"),
+                (f"Date: {start.strftime('%Y-%m-%d')}", "date"),
+                (f"Name: {description}", "name"),
+                (f"Amount: {amount}", "amount"),
+                (f"To: {to_label}", "to"),
+                (f"Recurring: {freq}", "recurring"),
+                ("Save", "save"),
+                ("Cancel", "cancel"),
+            ],
+            default=default,
+        )
+
+        if choice == "name":
+            new_desc = text(stdscr, "Name", default=description)
+            if new_desc is not None:
+                description = new_desc
+            default = "amount"
+        elif choice == "date":
+            date_str = text(
+                stdscr, "Date (YYYY-MM-DD)", default=start.strftime("%Y-%m-%d")
+            )
+            if date_str is not None:
+                try:
+                    start = datetime.strptime(date_str, "%Y-%m-%d")
+                except ValueError:
+                    pass
+        elif choice == "amount":
+            amount_str = text(stdscr, "Amount", default=str(amount))
+            if amount_str is not None:
+                try:
+                    amount = float(amount_str)
+                except ValueError:
+                    pass
+            default = "recurring"
+        elif choice == "to":
+            accts = (
+                session.query(Account)
+                .filter(Account.archived == False, Account.id != from_acct.id)
+                .order_by(Account.name)
+                .all()
+            )
+            if accts:
+                to_acct = select(
+                    stdscr, "To account", [(a.name, a) for a in accts], default=to_acct
+                )
+        elif choice == "recurring":
+            picked = select(
+                stdscr, "Frequency", FREQUENCIES, default=freq
+            )
+            if picked is not None:
+                freq = picked
+            default = "save"
+        elif choice == "save":
+            return description, start, amount, to_acct, freq
+        elif choice == "from":
+            continue
+        else:
+            return None
+
+
 def add_recurring(stdscr, is_income: bool, existing: Recurring | None = None) -> None:
     """Prompt user to add or edit a recurring bill or income."""
 
-    name = text(stdscr, "Name", default=existing.description if existing else None)
-    if name is None:
-        return
-    date_str = text(
-        stdscr,
-        "Start date (YYYY-MM-DD)",
-        default=existing.start_date.strftime("%Y-%m-%d") if existing else None,
-    )
-    if date_str is None:
-        return
-    amount_str = text(
-        stdscr,
-        "Amount",
-        default=str(abs(existing.amount)) if existing else None,
-    )
-    if amount_str is None:
-        return
-    freq = select(
-        stdscr,
-        "Frequency",
-        FREQUENCIES,
-        default=existing.frequency if existing else None,
-    )
-    try:
-        start = datetime.strptime(date_str, "%Y-%m-%d")
-        amount = float(amount_str)
-    except ValueError:
-        return
-    amount = abs(amount) if is_income else -abs(amount)
     session = SessionLocal()
     try:
         if existing is not None:
@@ -580,29 +633,100 @@ def add_recurring(stdscr, is_income: bool, existing: Recurring | None = None) ->
             default_acct = session.get(Account, CURRENT_ACCOUNT_IDS[0])
         else:
             default_acct = None
-        acct = pick_account(stdscr, session, "Account", default=default_acct)
-        if acct is None:
+        from_acct = pick_account(stdscr, session, "From account", default=default_acct)
+        if from_acct is None:
             return
-        account_id = acct.id
-        if existing is None:
-            rec = Recurring(
-                description=name,
-                amount=amount,
-                start_date=start,
-                frequency=freq,
-                account_id=account_id,
+        description = existing.description if existing else ""
+        start = existing.start_date if existing else datetime.utcnow()
+        amount = abs(existing.amount) if existing else 0.0
+        freq = existing.frequency if existing else "monthly"
+        to_acct = None
+        if existing and existing.transfer_id:
+            other = (
+                session.query(Recurring)
+                .filter(Recurring.transfer_id == existing.transfer_id, Recurring.id != existing.id)
+                .first()
             )
-            session.add(rec)
+            if other:
+                to_acct = session.get(Account, other.account_id)
+
+        form = recurring_form(
+            stdscr, session, from_acct, description, start, amount, to_acct, freq
+        )
+        if form is None:
+            return
+        description, start, amount, to_acct, freq = form
+
+        if existing is None:
+            if to_acct is None:
+                amt = abs(amount) if is_income else -abs(amount)
+                rec = Recurring(
+                    description=description,
+                    amount=amt,
+                    start_date=start,
+                    frequency=freq,
+                    account_id=from_acct.id,
+                )
+                session.add(rec)
+                session.commit()
+            else:
+                create_recurring_transfer(
+                    session,
+                    from_acct.id,
+                    to_acct.id,
+                    amount,
+                    start,
+                    freq,
+                    description,
+                )
         else:
             rec = session.get(Recurring, existing.id)
             if rec is None:
                 return
-            rec.description = name
-            rec.amount = amount
-            rec.start_date = start
-            rec.frequency = freq
-            rec.account_id = account_id
-        session.commit()
+            if rec.transfer_id:
+                if to_acct is None:
+                    delete_recurring_transfer(session, rec.transfer_id)
+                    amt = abs(amount) if is_income else -abs(amount)
+                    rec = Recurring(
+                        description=description,
+                        amount=amt,
+                        start_date=start,
+                        frequency=freq,
+                        account_id=from_acct.id,
+                    )
+                    session.add(rec)
+                    session.commit()
+                else:
+                    update_recurring_transfer(
+                        session,
+                        rec.transfer_id,
+                        description,
+                        amount,
+                        start,
+                        freq,
+                        from_acct.id,
+                        to_acct.id,
+                    )
+            else:
+                if to_acct is None:
+                    rec.description = description
+                    rec.amount = abs(amount) if is_income else -abs(amount)
+                    rec.start_date = start
+                    rec.frequency = freq
+                    rec.account_id = from_acct.id
+                    session.commit()
+                else:
+                    session.delete(rec)
+                    session.commit()
+                    create_recurring_transfer(
+                        session,
+                        from_acct.id,
+                        to_acct.id,
+                        amount,
+                        start,
+                        freq,
+                        description,
+                    )
     finally:
         session.close()
 
@@ -739,8 +863,11 @@ def edit_recurring(stdscr, is_income: bool) -> None:
             if del_idx < len(recs):
                 rec = recs[del_idx]
                 if confirm(stdscr, "Delete this item?"):
-                    session.delete(rec)
-                    session.commit()
+                    if rec.transfer_id:
+                        delete_recurring_transfer(session, rec.transfer_id)
+                    else:
+                        session.delete(rec)
+                        session.commit()
             session.close()
             session = SessionLocal()
             continue

--- a/budget/cli.py
+++ b/budget/cli.py
@@ -31,7 +31,14 @@ from .services_irregular import (
     update_irregular_state,
     get_or_create_state,
 )
-from .services import occurrences_between, create_transfer, max_safe_payment_today
+from .services import (
+    occurrences_between,
+    create_transaction,
+    create_transfer,
+    delete_transfer,
+    update_transfer,
+    max_safe_payment_today,
+)
 
 FREQUENCIES = [
     "weekly",
@@ -309,29 +316,43 @@ def toast(stdscr, msg: str, ms: int = 900):
         curses.napms(ms)
 
 
-def transaction_form(stdscr, description: str, timestamp: datetime, amount: float):
-    """Interactive form for editing transaction fields.
+def transaction_form(
+    stdscr,
+    session,
+    from_acct: Account,
+    description: str,
+    timestamp: datetime,
+    amount: float,
+    to_acct: Account | None = None,
+):
+    """Interactive form for adding/editing transactions with optional transfer.
 
-    Returns ``(description, timestamp, amount)`` if saved, otherwise ``None``.
+    Returns ``(description, timestamp, amount, to_acct)`` if saved, otherwise ``None``.
     """
 
+    default = "name"
     while True:
+        to_label = to_acct.name if to_acct else "Outgoing transaction"
         choice = select(
             stdscr,
             "Select field to edit",
             choices=[
-                (f"Name: {description}", "description"),
+                (f"From: {from_acct.name}", "from"),
                 (f"Date: {timestamp.strftime('%Y-%m-%d')}", "date"),
+                (f"Name: {description}", "name"),
                 (f"Amount: {amount}", "amount"),
+                (f"To: {to_label}", "to"),
                 ("Save", "save"),
                 ("Cancel", "cancel"),
             ],
+            default=default,
         )
 
-        if choice == "description":
-            new_desc = text(stdscr, "Description", default=description)
+        if choice == "name":
+            new_desc = text(stdscr, "Name", default=description)
             if new_desc is not None:
                 description = new_desc
+            default = "amount"
         elif choice == "date":
             date_str = text(
                 stdscr, "Date (YYYY-MM-DD)", default=timestamp.strftime("%Y-%m-%d")
@@ -348,8 +369,23 @@ def transaction_form(stdscr, description: str, timestamp: datetime, amount: floa
                     amount = float(amount_str)
                 except ValueError:
                     pass
+            default = "save"
+        elif choice == "to":
+            accts = (
+                session.query(Account)
+                .filter(Account.archived == False, Account.id != from_acct.id)
+                .order_by(Account.name)
+                .all()
+            )
+            if accts:
+                picked = select(
+                    stdscr, "To account", [(a.name, a) for a in accts], default=to_acct
+                )
+                to_acct = picked
         elif choice == "save":
-            return description, timestamp, amount
+            return description, timestamp, amount, to_acct
+        elif choice == "from":
+            continue
         else:
             return None
 
@@ -358,104 +394,48 @@ def add_transaction(stdscr) -> None:
     """Prompt user for transaction data and persist it."""
     session = SessionLocal()
     try:
+        default_acct = None
         if CURRENT_ACCOUNT_IDS and len(CURRENT_ACCOUNT_IDS) == 1:
-            account_id = CURRENT_ACCOUNT_IDS[0]
-        else:
-            acct = pick_account(stdscr, session, "Transaction account")
-            if acct is None:
-                return
-            account_id = acct.id
+            default_acct = session.get(Account, CURRENT_ACCOUNT_IDS[0])
+        from_acct = pick_account(stdscr, session, "From account", default=default_acct)
+        if from_acct is None:
+            return
 
-        form = transaction_form(stdscr, "", datetime.utcnow(), 0.0)
+        form = transaction_form(
+            stdscr, session, from_acct, "", datetime.utcnow(), 0.0, None
+        )
         if form is None:
             return
-        description, timestamp, amount = form
-        txn = Transaction(
-            account_id=account_id,
-            description=description,
-            amount=amount,
-            timestamp=timestamp,
-        )
-        session.add(txn)
-        session.commit()
+        description, timestamp, amount, to_acct = form
+        if to_acct is None:
+            txn = create_transaction(
+                session, from_acct.id, description, amount, timestamp
+            )
+        else:
+            create_transfer(
+                session, from_acct.id, to_acct.id, amount, timestamp, description
+            )
+            txn = None
 
-        category_id = match_category_id(session, txn.description, txn.account_id)
-        if category_id is not None:
-            state = get_or_create_state(session, category_id)
-            update_irregular_state(state, txn)
-            session.commit()
-            cat = session.get(IrregularCategory, category_id)
-            if cat is not None:
-                avg = state.avg_gap_days if state.avg_gap_days is not None else 0.0
-                med = state.median_amount if state.median_amount is not None else 0.0
-                toast(
-                    stdscr,
-                    f"Updated \u2018{cat.name}\u2019: avg gap \u2192 {avg:.1f} days, median \u2192 ${med:.2f}",
-                )
+        if txn is not None:
+            category_id = match_category_id(session, txn.description, txn.account_id)
+            if category_id is not None:
+                state = get_or_create_state(session, category_id)
+                update_irregular_state(state, txn)
+                session.commit()
+                cat = session.get(IrregularCategory, category_id)
+                if cat is not None:
+                    avg = state.avg_gap_days if state.avg_gap_days is not None else 0.0
+                    med = (
+                        state.median_amount if state.median_amount is not None else 0.0
+                    )
+                    toast(
+                        stdscr,
+                        f"Updated \u2018{cat.name}\u2019: avg gap \u2192 {avg:.1f} days, median \u2192 ${med:.2f}",
+                    )
     finally:
         session.close()
 
-
-def add_transfer(stdscr) -> None:
-    """Prompt user for transfer details and persist it."""
-
-    session = SessionLocal()
-    try:
-        accounts = (
-            session.query(Account)
-            .filter(Account.archived == False)
-            .order_by(Account.name)
-            .all()
-        )
-        if len(accounts) < 2:
-            return
-
-        default_from = None
-        if CURRENT_ACCOUNT_IDS and len(CURRENT_ACCOUNT_IDS) == 1:
-            default_from = session.get(Account, CURRENT_ACCOUNT_IDS[0])
-
-        from_acc = pick_account(
-            stdscr, session, "From account", default=default_from
-        )
-        if from_acc is None:
-            return
-
-        dest_accts = [a for a in accounts if a.id != from_acc.id]
-        if not dest_accts:
-            return
-        to_acc = select(
-            stdscr, "To account", [(a.name, a) for a in dest_accts]
-        )
-        if to_acc is None:
-            return
-
-        amt_str = text(stdscr, "Amount")
-        if amt_str is None:
-            return
-        try:
-            amount = float(amt_str)
-        except ValueError:
-            return
-
-        when_str = text(
-            stdscr,
-            "Date/time (YYYY-MM-DD HH:MM)",
-            default=datetime.utcnow().strftime("%Y-%m-%d %H:%M"),
-        )
-        if when_str is None:
-            return
-        try:
-            when = datetime.strptime(when_str, "%Y-%m-%d %H:%M")
-        except ValueError:
-            when = datetime.utcnow()
-
-        desc = text(stdscr, "Description", default="Transfer")
-        if desc is None:
-            desc = "Transfer"
-
-        create_transfer(session, from_acc.id, to_acc.id, amount, when, desc)
-    finally:
-        session.close()
 
 
 def max_payment_today_menu(stdscr) -> None:
@@ -781,14 +761,30 @@ def edit_recurring(stdscr, is_income: bool) -> None:
 
 def edit_transaction(stdscr, session, txn: Transaction) -> None:
     """Edit an existing transaction in-place."""
-    form = transaction_form(stdscr, txn.description, txn.timestamp, txn.amount)
+    from_acct = session.get(Account, txn.account_id)
+    to_acct = None
+    if txn.transfer_id:
+        other = (
+            session.query(Transaction)
+            .filter(Transaction.transfer_id == txn.transfer_id, Transaction.id != txn.id)
+            .first()
+        )
+        if other:
+            to_acct = session.get(Account, other.account_id)
+    amt = abs(txn.amount) if txn.transfer_id else txn.amount
+    form = transaction_form(
+        stdscr, session, from_acct, txn.description, txn.timestamp, amt, to_acct
+    )
     if form is None:
         return
-    description, timestamp, amount = form
-    txn.description = description
-    txn.timestamp = timestamp
-    txn.amount = amount
-    session.commit()
+    description, timestamp, amount, _ = form
+    if txn.transfer_id:
+        update_transfer(session, txn.transfer_id, description, amount, timestamp)
+    else:
+        txn.description = description
+        txn.timestamp = timestamp
+        txn.amount = amount
+        session.commit()
 
 
 def list_transactions(stdscr) -> None:
@@ -820,8 +816,11 @@ def list_transactions(stdscr) -> None:
             if del_idx < len(txns):
                 txn = txns[del_idx]
                 if confirm(stdscr, "Delete this transaction?"):
-                    session.delete(txn)
-                    session.commit()
+                    if txn.transfer_id:
+                        delete_transfer(session, txn.transfer_id)
+                    else:
+                        session.delete(txn)
+                        session.commit()
             session.close()
             session = SessionLocal()
             continue
@@ -1497,6 +1496,18 @@ def ledger_curses(
                 index = 0
             elif key == curses.KEY_END:
                 index = len(rows) - 1
+            elif key == ord("a"):
+                add_transaction(stdscr)
+                current_ts = rows[index].timestamp
+                if hasattr(get_prev, "refresh"):
+                    new_row = get_prev.refresh(current_ts)
+                    rows = [new_row]
+                    index = 0
+                    desc_w = len(new_row.description)
+                    amt_w = len(f"{new_row.amount:.2f}")
+                    run_w = len(f"{new_row.running_account:.2f}")
+                    if multi:
+                        tot_w = len(f"{new_row.running_total:.2f}")
             elif key in (ord("t"), ord("T")):
                 if IRREG_MODE == "deterministic":
                     IRREG_MODE = "monte_carlo"
@@ -2335,7 +2346,6 @@ def main(stdscr) -> None:
                 "Select an option",
                 choices=[
                     "List transactions",
-                    "New Transfer",
                     "Max Safe Payment (today)",
                     "Edit bills",
                     "Edit income",
@@ -2351,8 +2361,6 @@ def main(stdscr) -> None:
             )
             if choice == "List transactions":
                 list_transactions(stdscr)
-            elif choice == "New Transfer":
-                add_transfer(stdscr)
             elif choice == "Max Safe Payment (today)":
                 max_payment_today_menu(stdscr)
             elif choice == "Edit bills":

--- a/budget/cli.py
+++ b/budget/cli.py
@@ -400,47 +400,62 @@ def add_transfer(stdscr) -> None:
     """Prompt user for transfer details and persist it."""
 
     session = SessionLocal()
-    accounts = session.query(Account).filter(Account.archived == False).all()
-    if len(accounts) < 2:
-        session.close()
-        return
-
-    from_name = select(stdscr, "From account", [a.name for a in accounts])
-    if from_name is None:
-        session.close()
-        return
-    from_acc = next(a for a in accounts if a.name == from_name)
-
-    dest_choices = [a.name for a in accounts if a.id != from_acc.id]
-    to_name = select(stdscr, "To account", dest_choices)
-    if to_name is None:
-        session.close()
-        return
-    to_acc = next(a for a in accounts if a.name == to_name)
-
-    amt_str = text(stdscr, "Amount")
-    if amt_str is None:
-        session.close()
-        return
     try:
-        amount = float(amt_str)
-    except ValueError:
-        session.close()
-        return
+        accounts = (
+            session.query(Account)
+            .filter(Account.archived == False)
+            .order_by(Account.name)
+            .all()
+        )
+        if len(accounts) < 2:
+            return
 
-    date_str = text(
-        stdscr, "Date (YYYY-MM-DD)", default=datetime.utcnow().strftime("%Y-%m-%d")
-    )
-    if date_str is None:
-        session.close()
-        return
-    try:
-        when = datetime.strptime(date_str, "%Y-%m-%d")
-    except ValueError:
-        when = datetime.utcnow()
+        default_from = None
+        if CURRENT_ACCOUNT_IDS and len(CURRENT_ACCOUNT_IDS) == 1:
+            default_from = session.get(Account, CURRENT_ACCOUNT_IDS[0])
 
-    create_transfer(session, from_acc.id, to_acc.id, amount, when)
-    session.close()
+        from_acc = pick_account(
+            stdscr, session, "From account", default=default_from
+        )
+        if from_acc is None:
+            return
+
+        dest_accts = [a for a in accounts if a.id != from_acc.id]
+        if not dest_accts:
+            return
+        to_acc = select(
+            stdscr, "To account", [(a.name, a) for a in dest_accts]
+        )
+        if to_acc is None:
+            return
+
+        amt_str = text(stdscr, "Amount")
+        if amt_str is None:
+            return
+        try:
+            amount = float(amt_str)
+        except ValueError:
+            return
+
+        when_str = text(
+            stdscr,
+            "Date/time (YYYY-MM-DD HH:MM)",
+            default=datetime.utcnow().strftime("%Y-%m-%d %H:%M"),
+        )
+        if when_str is None:
+            return
+        try:
+            when = datetime.strptime(when_str, "%Y-%m-%d %H:%M")
+        except ValueError:
+            when = datetime.utcnow()
+
+        desc = text(stdscr, "Description", default="Transfer")
+        if desc is None:
+            desc = "Transfer"
+
+        create_transfer(session, from_acc.id, to_acc.id, amount, when, desc)
+    finally:
+        session.close()
 
 
 def max_payment_today_menu(stdscr) -> None:
@@ -2295,7 +2310,7 @@ def main(stdscr) -> None:
                 "Select an option",
                 choices=[
                     "List transactions",
-                    "New transfer",
+                    "New Transfer",
                     "Max safe payment (today)",
                     "Edit bills",
                     "Edit income",
@@ -2311,7 +2326,7 @@ def main(stdscr) -> None:
             )
             if choice == "List transactions":
                 list_transactions(stdscr)
-            elif choice == "New transfer":
+            elif choice == "New Transfer":
                 add_transfer(stdscr)
             elif choice == "Max safe payment (today)":
                 max_payment_today_menu(stdscr)

--- a/budget/cli.py
+++ b/budget/cli.py
@@ -1757,7 +1757,14 @@ def ledger_view(stdscr) -> None:
 
 
 def irregular_category_form(
-    stdscr, name: str, window_days: int, alpha: float, safety_q: float, active: bool
+    stdscr,
+    session,
+    name: str,
+    window_days: int,
+    alpha: float,
+    safety_q: float,
+    active: bool,
+    account: Account | None = None,
 ):
     """Prompt for irregular category fields and return updated values."""
 
@@ -1776,6 +1783,15 @@ def irregular_category_form(
     active_str = text(stdscr, "Active (Y/N)", default="Y" if active else "N")
     if active_str is None:
         return None
+    if account is not None:
+        default_acct = account
+    elif CURRENT_ACCOUNT_IDS and len(CURRENT_ACCOUNT_IDS) == 1:
+        default_acct = session.get(Account, CURRENT_ACCOUNT_IDS[0])
+    else:
+        default_acct = None
+    acct = pick_account(stdscr, session, "Account", default=default_acct)
+    if acct is None:
+        return None
     try:
         window_days_val = int(win_str)
         alpha_val = float(alpha_str)
@@ -1783,7 +1799,14 @@ def irregular_category_form(
     except ValueError:
         return None
     active_val = active_str.strip().lower() in ("y", "yes", "true", "1")
-    return name_new, window_days_val, alpha_val, safety_val, active_val
+    return (
+        name_new,
+        window_days_val,
+        alpha_val,
+        safety_val,
+        active_val,
+        acct.id,
+    )
 
 
 def edit_irregular_category(
@@ -1791,17 +1814,22 @@ def edit_irregular_category(
 ) -> None:
     """Add or edit an irregular category."""
 
+    existing_acct = (
+        session.get(Account, existing.account_id) if existing else None
+    )
     form = irregular_category_form(
         stdscr,
+        session,
         existing.name if existing else "",
         existing.window_days if existing else 120,
         existing.alpha if existing else 0.3,
         existing.safety_quantile if existing else 0.8,
         existing.active if existing else True,
+        existing_acct,
     )
     if form is None:
         return
-    name, window_days, alpha, safety_q, active = form
+    name, window_days, alpha, safety_q, active, account_id = form
     if existing is None:
         cat = IrregularCategory(
             name=name,
@@ -1809,6 +1837,7 @@ def edit_irregular_category(
             alpha=alpha,
             safety_quantile=safety_q,
             active=active,
+            account_id=account_id,
         )
         session.add(cat)
     else:
@@ -1820,6 +1849,9 @@ def edit_irregular_category(
         cat.alpha = alpha
         cat.safety_quantile = safety_q
         cat.active = active
+        cat.account_id = account_id
+        for rule in cat.rules:
+            rule.account_id = account_id
     session.commit()
 
 
@@ -1841,7 +1873,9 @@ def irregular_rules_menu(stdscr, category: IrregularCategory) -> None:
             h, w = stdscr.getmaxyx()
             h = max(1, h)
             w = max(1, w)
-            header = f"Rules for {category.name}"
+            acct = session.get(Account, category.account_id)
+            acct_name = acct.name if acct else ""
+            header = f"Rules for {category.name} ({acct_name})"
             offset = 1
             visible = min(len(entries), h - 1 - offset)
             top = min(max(0, index - visible // 2), max(0, len(entries) - visible))
@@ -1901,7 +1935,10 @@ def irregular_rules_menu(stdscr, category: IrregularCategory) -> None:
                 if pattern:
                     session.add(
                         IrregularRule(
-                            category_id=category.id, pattern=pattern, active=True
+                            category_id=category.id,
+                            account_id=category.account_id,
+                            pattern=pattern,
+                            active=True,
                         )
                     )
                     session.commit()
@@ -1966,8 +2003,19 @@ def irregular_menu(stdscr) -> None:
         while True:
             cats = categories(session)
             name_w = max((len(c.name) for c in cats), default=0)
+            acct_map = {
+                a.id: a.name
+                for a in session.query(Account)
+                .filter(Account.id.in_([c.account_id for c in cats]))
+                .all()
+            }
+            acct_w = max((len(acct_map.get(c.account_id, "")) for c in cats), default=0)
             entries = [
-                f"{c.name:<{name_w}} | {c.window_days:>3} | {c.alpha:.2f} | {c.safety_quantile:.2f} | {'Y' if c.active else 'N'}"
+                (
+                    f"{c.name:<{name_w}} | {acct_map.get(c.account_id, ''):<{acct_w}} | "
+                    f"{c.window_days:>3} | {c.alpha:.2f} | {c.safety_quantile:.2f} | "
+                    f"{'Y' if c.active else 'N'}"
+                )
                 for c in cats
             ]
 

--- a/budget/cli.py
+++ b/budget/cli.py
@@ -51,6 +51,8 @@ INITIAL_FORWARD_MONTHS = 18
 EXTEND_CHUNK_MONTHS = 6
 EDGE_TRIGGER_DAYS = 14
 
+CURRENT_ACCOUNT_IDS: list[int] | None = None  # None means "All Accounts"
+
 
 def select(stdscr, message, choices, default=None, boxed=True):
     """Display a scrollable menu and return the selected value.
@@ -89,6 +91,23 @@ def select(stdscr, message, choices, default=None, boxed=True):
     if selected is None:
         return None
     return values[selected]
+
+
+def list_accounts(session):
+    return (
+        session.query(Account)
+        .filter(Account.archived == False)
+        .order_by(Account.name)
+        .all()
+    )
+
+
+def pick_account(stdscr, session, prompt="Select account"):
+    accts = list_accounts(session)
+    if not accts:
+        return None
+    choice = select(stdscr, prompt, [(a.name, a) for a in accts])
+    return choice
 
 
 def _center_box(stdscr, height: int, width: int) -> "curses.window":
@@ -406,18 +425,72 @@ def max_payment_today_menu(stdscr) -> None:
     toast(stdscr, f"You can safely pay ${amt:.2f} to {target.name} today.")
 
 
-def choose_account_scope(stdscr, current: list[int]) -> list[int] | None:
+def accounts_menu(stdscr) -> None:
+    global CURRENT_ACCOUNT_IDS
     session = SessionLocal()
-    accounts = (
-        session.query(Account)
-        .filter(Account.archived == False)
-        .order_by(Account.name)
-        .all()
-    )
-    session.close()
-    all_ids = [a.id for a in accounts]
-    choices = [("All accounts", all_ids)] + [(a.name, [a.id]) for a in accounts]
-    return select(stdscr, "Accounts", choices, default=current)
+    ensure_default_account(session)
+    try:
+        while True:
+            choice = select(
+                stdscr,
+                "Accounts",
+                [
+                    "All Accounts",
+                    "New Account",
+                    "Rename Account",
+                    "Delete Account",
+                    "Select Single Account",
+                    "Back",
+                ],
+                boxed=False,
+            )
+            if choice == "All Accounts":
+                CURRENT_ACCOUNT_IDS = None
+            elif choice == "New Account":
+                name = text(stdscr, "Account name")
+                if name is None:
+                    continue
+                acc_type = select(
+                    stdscr,
+                    "Account type",
+                    ["checking", "savings", "credit_card", "loan"],
+                )
+                if acc_type is None:
+                    continue
+                session.add(Account(name=name, type=acc_type))
+                session.commit()
+            elif choice == "Rename Account":
+                acct = pick_account(stdscr, session, "Rename which account")
+                if acct:
+                    new_name = text(stdscr, "New name", acct.name)
+                    if new_name is not None:
+                        acct.name = new_name
+                        session.commit()
+            elif choice == "Delete Account":
+                acct = pick_account(stdscr, session, "Delete which account")
+                if acct:
+                    has_tx = (
+                        session.query(Transaction)
+                        .filter_by(account_id=acct.id)
+                        .first()
+                        is not None
+                    )
+                    if has_tx and not confirm(
+                        stdscr, "Account has transactions; delete anyway?"
+                    ):
+                        continue
+                    session.delete(acct)
+                    session.commit()
+                    if CURRENT_ACCOUNT_IDS and acct.id in CURRENT_ACCOUNT_IDS:
+                        CURRENT_ACCOUNT_IDS = None
+            elif choice == "Select Single Account":
+                acct = pick_account(stdscr, session, "Select account")
+                if acct:
+                    CURRENT_ACCOUNT_IDS = [acct.id]
+            else:
+                break
+    finally:
+        session.close()
 
 
 def add_recurring(stdscr, is_income: bool, existing: Recurring | None = None) -> None:
@@ -1452,15 +1525,27 @@ def scroll_menu(
                 return None
 
 
-def ledger_view(stdscr, account_scope: list[int] | None = None) -> None:
+def ledger_view(stdscr) -> None:
     """Display a scrollable ledger as ``date | name | amount | balance``."""
     session = SessionLocal()
-    default_acc = ensure_default_account(session)
-    if account_scope is None:
-        account_scope = [default_acc.id]
-    accounts = session.query(Account).filter(Account.id.in_(account_scope)).all()
+    ensure_default_account(session)
+    account_ids = CURRENT_ACCOUNT_IDS
+    if account_ids is None:
+        accounts = (
+            session.query(Account)
+            .filter(Account.archived == False)
+            .order_by(Account.name)
+            .all()
+        )
+        account_ids = [a.id for a in accounts]
+    else:
+        accounts = session.query(Account).filter(Account.id.in_(account_ids)).all()
+    if not account_ids:
+        default_acc = ensure_default_account(session)
+        account_ids = [default_acc.id]
+        accounts = [default_acc]
     bal_amt = 0.0
-    for aid in account_scope:
+    for aid in account_ids:
         bal = (
             session.query(Balance)
             .filter(Balance.account_id == aid)
@@ -1472,7 +1557,7 @@ def ledger_view(stdscr, account_scope: list[int] | None = None) -> None:
 
     earliest_tx = (
         session.query(Transaction)
-        .filter(Transaction.account_id.in_(account_scope))
+        .filter(Transaction.account_id.in_(account_ids))
         .order_by(Transaction.timestamp)
         .first()
     )
@@ -1481,7 +1566,7 @@ def ledger_view(stdscr, account_scope: list[int] | None = None) -> None:
     plan_end = end_of_month(date.today(), INITIAL_FORWARD_MONTHS)
     account_names = {a.id: a.name for a in accounts}
 
-    rows = list(ledger_rows(session, plan_start, plan_end, account_scope))
+    rows = list(ledger_rows(session, plan_start, plan_end, account_ids))
     if not rows:
         session.close()
         return
@@ -1495,7 +1580,7 @@ def ledger_view(stdscr, account_scope: list[int] | None = None) -> None:
 
     def rebuild():
         nonlocal rows, ts_list
-        rows = list(ledger_rows(session, plan_start, plan_end, account_scope))
+        rows = list(ledger_rows(session, plan_start, plan_end, account_ids))
         ts_list = [r.timestamp for r in rows]
 
     def refresh(ts_current: datetime):
@@ -1536,7 +1621,7 @@ def ledger_view(stdscr, account_scope: list[int] | None = None) -> None:
         get_next,
         bal_amt,
         account_names,
-        len(account_scope) > 1,
+        len(account_ids) > 1,
     )
     session.close()
 
@@ -2021,12 +2106,11 @@ def main(stdscr) -> None:
         session = SessionLocal()
         try:
             try:
-                default_acc_id = ensure_default_account(session).id
+                ensure_default_account(session)
             except OperationalError:
-                default_acc_id = 1
+                pass
         finally:
             session.close()
-        account_scope = [default_acc_id]
         while True:
             choice = select(
                 stdscr,
@@ -2038,7 +2122,7 @@ def main(stdscr) -> None:
                     "Edit bills",
                     "Edit income",
                     "Irregular spending",
-                    "Accounts",
+                    "Accounts...",
                     "Ledger",
                     "Set balance",
                     "Wants/Goals",
@@ -2059,12 +2143,10 @@ def main(stdscr) -> None:
                 edit_recurring(stdscr, True)
             elif choice == "Irregular spending":
                 irregular_menu(stdscr)
-            elif choice == "Accounts":
-                new_scope = choose_account_scope(stdscr, account_scope)
-                if new_scope is not None:
-                    account_scope = new_scope
+            elif choice == "Accounts...":
+                accounts_menu(stdscr)
             elif choice == "Ledger":
-                ledger_view(stdscr, account_scope)
+                ledger_view(stdscr)
             elif choice == "Set balance":
                 set_balance(stdscr)
             elif choice == "Wants/Goals":

--- a/budget/cli.py
+++ b/budget/cli.py
@@ -78,14 +78,51 @@ def select(stdscr, message, choices, default=None, boxed=True):
             default_idx = idx
 
     with SessionLocal() as s:
-        bal = s.get(Balance, 1)
-        bal_amt = bal.amount if bal else 0.0
+        footer_right = ""
+        if CURRENT_ACCOUNT_IDS is None:
+            accts = list_accounts(s)
+        else:
+            accts = (
+                s.query(Account)
+                .filter(Account.id.in_(CURRENT_ACCOUNT_IDS))
+                .order_by(Account.name)
+                .all()
+            )
+        if accts:
+            if len(accts) == 1:
+                acct = accts[0]
+                bal_row = (
+                    s.query(Balance)
+                    .filter(Balance.account_id == acct.id)
+                    .order_by(Balance.timestamp.desc())
+                    .first()
+                )
+                amt = bal_row.amount if bal_row else 0.0
+                ts = (
+                    bal_row.timestamp.strftime("%Y-%m-%d")
+                    if bal_row and bal_row.timestamp
+                    else "n/a"
+                )
+                footer_right = f"{acct.name}: {amt:.2f} @ {ts}"
+            else:
+                parts: list[str] = []
+                for acct in accts:
+                    bal_row = (
+                        s.query(Balance)
+                        .filter(Balance.account_id == acct.id)
+                        .order_by(Balance.timestamp.desc())
+                        .first()
+                    )
+                    amt = bal_row.amount if bal_row else 0.0
+                    parts.append(f"{acct.name}:{amt:.2f}")
+                footer_right = "; ".join(parts)
+
     selected = scroll_menu(
         stdscr,
         titles,
         default_idx,
         header=message,
-        footer_right=f"{bal_amt:.2f}",
+        footer_right=footer_right,
         boxed=boxed,
     )
     if selected is None:
@@ -769,25 +806,88 @@ def list_transactions(stdscr) -> None:
     session.close()
 
 
+def _show_balances(stdscr, lines: list[str]) -> None:
+    if not lines:
+        return
+    width = max(len(line) for line in lines) + 4
+    height = len(lines) + 2
+    with modal_box(stdscr, height, width) as win:
+        for idx, line in enumerate(lines, start=1):
+            try:
+                win.addnstr(idx, 2, line, width - 4)
+            except curses.error:
+                pass
+        try:
+            win.refresh()
+        except curses.error:
+            pass
+        win.getch()
+
+
 def set_balance(stdscr) -> None:
     """Prompt the user to store their current balance."""
-    amount_str = text(stdscr, "Current balance")
-    if amount_str is None:
-        return
-    try:
-        amount = float(amount_str)
-    except ValueError:
-        return
     session = SessionLocal()
-    bal = session.get(Balance, 1)
-    if bal is None:
-        bal = Balance(id=1, amount=amount, timestamp=datetime.utcnow())
-        session.add(bal)
-    else:
-        bal.amount = amount
-        bal.timestamp = datetime.utcnow()
-    session.commit()
-    session.close()
+    try:
+        acct: Account | None
+        if CURRENT_ACCOUNT_IDS and len(CURRENT_ACCOUNT_IDS) == 1:
+            acct = session.get(Account, CURRENT_ACCOUNT_IDS[0])
+        else:
+            # Show existing balances for context
+            scope_ids = (
+                CURRENT_ACCOUNT_IDS
+                if CURRENT_ACCOUNT_IDS is not None
+                else [a.id for a in list_accounts(session)]
+            )
+            lines: list[str] = []
+            for aid in scope_ids:
+                a = session.get(Account, aid)
+                bal_row = (
+                    session.query(Balance)
+                    .filter(Balance.account_id == aid)
+                    .order_by(Balance.timestamp.desc())
+                    .first()
+                )
+                amt = bal_row.amount if bal_row else 0.0
+                ts = (
+                    bal_row.timestamp.strftime("%Y-%m-%d")
+                    if bal_row and bal_row.timestamp
+                    else "n/a"
+                )
+                lines.append(f"{a.name}: {amt:.2f} @ {ts}")
+            _show_balances(stdscr, lines)
+            acct = pick_account(stdscr, session, "Balance for account")
+        if acct is None:
+            return
+
+        bal_row = (
+            session.query(Balance)
+            .filter(Balance.account_id == acct.id)
+            .order_by(Balance.timestamp.desc())
+            .first()
+        )
+        default_amt = f"{bal_row.amount:.2f}" if bal_row else None
+        ts_str = (
+            bal_row.timestamp.strftime("%Y-%m-%d")
+            if bal_row and bal_row.timestamp
+            else "n/a"
+        )
+        amount_str = text(
+            stdscr,
+            f"Balance for {acct.name} (last {ts_str})",
+            default=default_amt,
+        )
+        if amount_str is None:
+            return
+        try:
+            amount = float(amount_str)
+        except ValueError:
+            return
+        session.add(
+            Balance(amount=amount, timestamp=datetime.utcnow(), account_id=acct.id)
+        )
+        session.commit()
+    finally:
+        session.close()
 
 
 def settings_help_menu(stdscr) -> None:

--- a/budget/cli.py
+++ b/budget/cli.py
@@ -319,30 +319,44 @@ def transaction_form(stdscr, description: str, timestamp: datetime, amount: floa
 
 def add_transaction(stdscr) -> None:
     """Prompt user for transaction data and persist it."""
-    form = transaction_form(stdscr, "", datetime.utcnow(), 0.0)
-    if form is None:
-        return
-    description, timestamp, amount = form
     session = SessionLocal()
-    txn = Transaction(description=description, amount=amount, timestamp=timestamp)
-    session.add(txn)
-    session.commit()
+    try:
+        if CURRENT_ACCOUNT_IDS and len(CURRENT_ACCOUNT_IDS) == 1:
+            account_id = CURRENT_ACCOUNT_IDS[0]
+        else:
+            acct = pick_account(stdscr, session, "Transaction account")
+            if acct is None:
+                return
+            account_id = acct.id
 
-    category_id = match_category_id(session, txn.description, txn.account_id)
-    if category_id is not None:
-        state = get_or_create_state(session, category_id)
-        update_irregular_state(state, txn)
+        form = transaction_form(stdscr, "", datetime.utcnow(), 0.0)
+        if form is None:
+            return
+        description, timestamp, amount = form
+        txn = Transaction(
+            account_id=account_id,
+            description=description,
+            amount=amount,
+            timestamp=timestamp,
+        )
+        session.add(txn)
         session.commit()
-        cat = session.get(IrregularCategory, category_id)
-        if cat is not None:
-            avg = state.avg_gap_days if state.avg_gap_days is not None else 0.0
-            med = state.median_amount if state.median_amount is not None else 0.0
-            toast(
-                stdscr,
-                f"Updated \u2018{cat.name}\u2019: avg gap \u2192 {avg:.1f} days, median \u2192 ${med:.2f}",
-            )
 
-    session.close()
+        category_id = match_category_id(session, txn.description, txn.account_id)
+        if category_id is not None:
+            state = get_or_create_state(session, category_id)
+            update_irregular_state(state, txn)
+            session.commit()
+            cat = session.get(IrregularCategory, category_id)
+            if cat is not None:
+                avg = state.avg_gap_days if state.avg_gap_days is not None else 0.0
+                med = state.median_amount if state.median_amount is not None else 0.0
+                toast(
+                    stdscr,
+                    f"Updated \u2018{cat.name}\u2019: avg gap \u2192 {avg:.1f} days, median \u2192 ${med:.2f}",
+                )
+    finally:
+        session.close()
 
 
 def add_transfer(stdscr) -> None:

--- a/budget/cli.py
+++ b/budget/cli.py
@@ -31,7 +31,7 @@ from .services_irregular import (
     update_irregular_state,
     get_or_create_state,
 )
-from .services import occurrences_between, create_transfer
+from .services import occurrences_between, create_transfer, max_safe_payment_today
 
 FREQUENCIES = [
     "weekly",
@@ -371,6 +371,39 @@ def add_transfer(stdscr) -> None:
 
     create_transfer(session, from_acc.id, to_acc.id, amount, when)
     session.close()
+
+
+def max_payment_today_menu(stdscr) -> None:
+    """Compute the maximum safe extra payment for today."""
+
+    session = SessionLocal()
+    accounts = (
+        session.query(Account).filter(Account.archived == False).order_by(Account.name).all()
+    )
+    if not accounts:
+        session.close()
+        return
+
+    target_name = select(stdscr, "Target account", [a.name for a in accounts])
+    if target_name is None:
+        session.close()
+        return
+    target = next(a for a in accounts if a.name == target_name)
+
+    buffer_by_account: dict[int, float] = {}
+    for acc in accounts:
+        buf_str = text(stdscr, f"Buffer for {acc.name}", default="100")
+        if buf_str is None:
+            session.close()
+            return
+        try:
+            buffer_by_account[acc.id] = float(buf_str)
+        except ValueError:
+            buffer_by_account[acc.id] = 0.0
+
+    amt = max_safe_payment_today(session, target.id, buffer_by_account)
+    session.close()
+    toast(stdscr, f"You can safely pay ${amt:.2f} to {target.name} today.")
 
 
 def choose_account_scope(stdscr, current: list[int]) -> list[int] | None:
@@ -2001,6 +2034,7 @@ def main(stdscr) -> None:
                 choices=[
                     "List transactions",
                     "New transfer",
+                    "Max safe payment (today)",
                     "Edit bills",
                     "Edit income",
                     "Irregular spending",
@@ -2017,6 +2051,8 @@ def main(stdscr) -> None:
                 list_transactions(stdscr)
             elif choice == "New transfer":
                 add_transfer(stdscr)
+            elif choice == "Max safe payment (today)":
+                max_payment_today_menu(stdscr)
             elif choice == "Edit bills":
                 edit_recurring(stdscr, False)
             elif choice == "Edit income":

--- a/budget/cli.py
+++ b/budget/cli.py
@@ -1410,18 +1410,31 @@ def ledger_rows(
             return (20, 0) if amt > 0 else (30, 0)
         return (20, 0) if amt > 0 else (40, 0)
 
-    txns.sort(
-        key=lambda t: (
-            t.timestamp.date(),
-            classify_priority(t)[0],
-            classify_priority(t)[1],
-            getattr(t, "id", 0),
-            t.account_id,
-            t.description or "",
-            float(f"{abs(t.amount):.2f}"),
+    def _ledger_sort_key(t: Transaction):
+        prio, rank = classify_priority(t)
+        date_key = t.timestamp.date()
+        src_key = getattr(t, "_source_type", "posted") or "posted"
+        acct_key = t.account_id if t.account_id is not None else -1
+        id_key = t.id if t.id is not None else 0
+        desc_key = t.description or ""
+        amt_key = 0.0 if t.amount is None else float(f"{abs(t.amount):.2f}")
+        return (
+            date_key,
+            prio,
+            rank,
+            src_key,
+            acct_key,
+            id_key,
+            desc_key,
+            amt_key,
             t.timestamp,
         )
-    )
+
+    for t in txns:
+        assert t.timestamp is not None
+        assert isinstance(t.account_id if t.account_id is not None else -1, int)
+
+    txns.sort(key=_ledger_sort_key)
 
     def is_posted(t):
         return getattr(t, "_source_type", "posted") == "posted"

--- a/budget/cli.py
+++ b/budget/cli.py
@@ -1348,11 +1348,18 @@ def ledger_curses(
     index = 0
 
     with temp_cursor(0), keypad_mode(stdscr):
-        desc_w = len(initial_row.description)
-        amt_w = len(f"{initial_row.amount:.2f}")
-        run_w = len(f"{initial_row.running_account:.2f}")
-        acct_w = max(len(n) for n in account_names.values()) if multi else 0
-        tot_w = len(f"{initial_row.running_total:.2f}") if multi else 0
+        if multi:
+            acct_w = max(len("Account"), max(len(n) for n in account_names.values()))
+            desc_w = max(len("Description"), len(initial_row.description))
+            amt_w = max(len("Amount"), len(f"{initial_row.amount:.2f}"))
+            run_w = max(len("Balance (Acct)"), len(f"{initial_row.running_account:.2f}"))
+            tot_w = max(len("Balance (Total)"), len(f"{initial_row.running_total:.2f}"))
+        else:
+            desc_w = max(len("Description"), len(initial_row.description))
+            amt_w = max(len("Amount"), len(f"{initial_row.amount:.2f}"))
+            run_w = max(len("Balance"), len(f"{initial_row.running_account:.2f}"))
+            acct_w = 0
+            tot_w = 0
         mode_label = (
             "Deterministic"
             if IRREG_MODE == "deterministic"
@@ -1364,7 +1371,7 @@ def ledger_curses(
             h, w = stdscr.getmaxyx()
             h = max(1, h)
             w = max(1, w)
-            visible = h - 1
+            visible = h - 2 if multi else h - 1
 
             while index < visible // 2:
                 prev_row = get_prev(rows[0].timestamp)
@@ -1392,6 +1399,23 @@ def ledger_curses(
             top = min(max(0, index - visible // 2), max(0, len(rows) - visible))
 
             stdscr.erase()
+            if multi:
+                header = (
+                    f"{'Date'} | "
+                    f"{'Account':<{acct_w}} | "
+                    f"{'Description':<{desc_w}} | "
+                    f"{'Amount':>{amt_w}} | "
+                    f"{'Balance (Acct)':>{run_w}} | "
+                    f"{'Balance (Total)':>{tot_w}}"
+                )
+                try:
+                    stdscr.addnstr(0, 0, header, w - 1, curses.A_BOLD)
+                except curses.error:
+                    pass
+                row_y_start = 1
+            else:
+                row_y_start = 0
+
             for i in range(visible):
                 line_idx = top + i
                 if line_idx >= len(rows):
@@ -1415,7 +1439,7 @@ def ledger_curses(
                     )
                 attr = curses.A_REVERSE if line_idx == index else curses.A_NORMAL
                 try:
-                    stdscr.addnstr(i, 0, line, w - 1, attr)
+                    stdscr.addnstr(row_y_start + i, 0, line, w - 1, attr)
                 except curses.error:
                     pass
 

--- a/budget/cli.py
+++ b/budget/cli.py
@@ -475,18 +475,19 @@ def max_payment_today_menu(stdscr) -> None:
         return
     target = next(a for a in accounts if a.name == target_name)
 
-    buffer_by_account: dict[int, float] = {}
-    for acc in accounts:
-        buf_str = text(stdscr, f"Buffer for {acc.name}", default="100")
-        if buf_str is None:
-            session.close()
-            return
-        try:
-            buffer_by_account[acc.id] = float(buf_str)
-        except ValueError:
-            buffer_by_account[acc.id] = 0.0
+    buf_str = text(stdscr, "Buffer per account", default="100")
+    if buf_str is None:
+        session.close()
+        return
+    try:
+        buf_val = float(buf_str)
+    except ValueError:
+        buf_val = 0.0
+    buffer_by_account = {acc.id: buf_val for acc in accounts}
 
-    amt = max_safe_payment_today(session, target.id, buffer_by_account)
+    amt = max_safe_payment_today(
+        session, target.id, buffer_by_account, horizon_days=120
+    )
     session.close()
     toast(stdscr, f"You can safely pay ${amt:.2f} to {target.name} today.")
 
@@ -2335,7 +2336,7 @@ def main(stdscr) -> None:
                 choices=[
                     "List transactions",
                     "New Transfer",
-                    "Max safe payment (today)",
+                    "Max Safe Payment (today)",
                     "Edit bills",
                     "Edit income",
                     "Irregular spending",
@@ -2352,7 +2353,7 @@ def main(stdscr) -> None:
                 list_transactions(stdscr)
             elif choice == "New Transfer":
                 add_transfer(stdscr)
-            elif choice == "Max safe payment (today)":
+            elif choice == "Max Safe Payment (today)":
                 max_payment_today_menu(stdscr)
             elif choice == "Edit bills":
                 edit_recurring(stdscr, False)

--- a/budget/cli.py
+++ b/budget/cli.py
@@ -139,11 +139,11 @@ def list_accounts(session):
     )
 
 
-def pick_account(stdscr, session, prompt="Select account"):
+def pick_account(stdscr, session, prompt="Select account", default=None):
     accts = list_accounts(session)
     if not accts:
         return None
-    choice = select(stdscr, prompt, [(a.name, a) for a in accts])
+    choice = select(stdscr, prompt, [(a.name, a) for a in accts], default=default)
     return choice
 
 
@@ -577,22 +577,38 @@ def add_recurring(stdscr, is_income: bool, existing: Recurring | None = None) ->
         return
     amount = abs(amount) if is_income else -abs(amount)
     session = SessionLocal()
-    if existing is None:
-        rec = Recurring(
-            description=name, amount=amount, start_date=start, frequency=freq
-        )
-        session.add(rec)
-    else:
-        rec = session.get(Recurring, existing.id)
-        if rec is None:
-            session.close()
+    try:
+        if existing is not None:
+            default_acct = session.get(Account, existing.account_id)
+        elif CURRENT_ACCOUNT_IDS and len(CURRENT_ACCOUNT_IDS) == 1:
+            default_acct = session.get(Account, CURRENT_ACCOUNT_IDS[0])
+        else:
+            default_acct = None
+        acct = pick_account(stdscr, session, "Account", default=default_acct)
+        if acct is None:
             return
-        rec.description = name
-        rec.amount = amount
-        rec.start_date = start
-        rec.frequency = freq
-    session.commit()
-    session.close()
+        account_id = acct.id
+        if existing is None:
+            rec = Recurring(
+                description=name,
+                amount=amount,
+                start_date=start,
+                frequency=freq,
+                account_id=account_id,
+            )
+            session.add(rec)
+        else:
+            rec = session.get(Recurring, existing.id)
+            if rec is None:
+                return
+            rec.description = name
+            rec.amount = amount
+            rec.start_date = start
+            rec.frequency = freq
+            rec.account_id = account_id
+        session.commit()
+    finally:
+        session.close()
 
 
 def goal_form(

--- a/budget/database.py
+++ b/budget/database.py
@@ -104,6 +104,14 @@ def init_db() -> None:
                     "CREATE INDEX IF NOT EXISTS ix_transactions_transfer_id ON transactions(transfer_id)"
                 )
             )
+        cols = [r[1] for r in conn.execute(text("PRAGMA table_info(recurring)"))]
+        if "transfer_id" not in cols:
+            conn.execute(text("ALTER TABLE recurring ADD COLUMN transfer_id TEXT"))
+            conn.execute(
+                text(
+                    "CREATE INDEX IF NOT EXISTS ix_recurring_transfer_id ON recurring(transfer_id)"
+                )
+            )
         # If a legacy balance row exists, duplicate it for the default account
         res = conn.execute(
             text("SELECT COUNT(*) FROM balance WHERE account_id = :acc"),

--- a/budget/database.py
+++ b/budget/database.py
@@ -95,6 +95,15 @@ def init_db() -> None:
                         f"CREATE INDEX IF NOT EXISTS ix_{table}_account_id_timestamp ON {table}(account_id, timestamp)"
                     )
                 )
+
+        cols = [r[1] for r in conn.execute(text("PRAGMA table_info(transactions)"))]
+        if "transfer_id" not in cols:
+            conn.execute(text("ALTER TABLE transactions ADD COLUMN transfer_id TEXT"))
+            conn.execute(
+                text(
+                    "CREATE INDEX IF NOT EXISTS ix_transactions_transfer_id ON transactions(transfer_id)"
+                )
+            )
         # If a legacy balance row exists, duplicate it for the default account
         res = conn.execute(
             text("SELECT COUNT(*) FROM balance WHERE account_id = :acc"),

--- a/budget/models.py
+++ b/budget/models.py
@@ -46,6 +46,13 @@ class Transaction(Base):
         nullable=False,
         default=1,
     )
+    transfer_group_id = Column(String, nullable=True, index=True)
+    counterparty_account_id = Column(
+        Integer,
+        ForeignKey("accounts.id"),
+        nullable=True,
+        index=True,
+    )
 
 
 class Balance(Base):

--- a/budget/models.py
+++ b/budget/models.py
@@ -49,11 +49,11 @@ class Transaction(Base):
 
 
 class Balance(Base):
-    """Stores the user's current balance."""
+    """Stores balance snapshots per account."""
 
     __tablename__ = "balance"
 
-    id = Column(Integer, primary_key=True, default=1)
+    id = Column(Integer, primary_key=True, autoincrement=True)
     amount = Column(Float, nullable=False, default=0.0)
     timestamp = Column(DateTime, default=datetime.utcnow)
     account_id = Column(
@@ -62,6 +62,10 @@ class Balance(Base):
         index=True,
         nullable=False,
         default=1,
+    )
+
+    __table_args__ = (
+        Index("ix_balance_account_id_timestamp", "account_id", "timestamp"),
     )
 
 

--- a/budget/models.py
+++ b/budget/models.py
@@ -118,7 +118,13 @@ class IrregularCategory(Base):
     window_days = Column(Integer, default=120)
     alpha = Column(Float, default=0.3)
     safety_quantile = Column(Float, default=0.8)
-    account_id = Column(Integer, ForeignKey("accounts.id"), nullable=True, index=True)
+    account_id = Column(
+        Integer,
+        ForeignKey("accounts.id"),
+        nullable=False,
+        index=True,
+        default=1,
+    )
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
@@ -171,6 +177,13 @@ class IrregularRule(Base):
     id = Column(Integer, primary_key=True)
     category_id = Column(
         Integer, ForeignKey("irregular_categories.id"), nullable=False, index=True
+    )
+    account_id = Column(
+        Integer,
+        ForeignKey("accounts.id"),
+        nullable=False,
+        index=True,
+        default=1,
     )
     pattern = Column(String, nullable=False)
     active = Column(Boolean, default=True)

--- a/budget/models.py
+++ b/budget/models.py
@@ -87,6 +87,7 @@ class Recurring(Base):
         nullable=False,
         default=1,
     )
+    transfer_id = Column(String, nullable=True, index=True)
 
 
 class Goal(Base):

--- a/budget/models.py
+++ b/budget/models.py
@@ -46,13 +46,7 @@ class Transaction(Base):
         nullable=False,
         default=1,
     )
-    transfer_group_id = Column(String, nullable=True, index=True)
-    counterparty_account_id = Column(
-        Integer,
-        ForeignKey("accounts.id"),
-        nullable=True,
-        index=True,
-    )
+    transfer_id = Column(String, nullable=True, index=True)
 
 
 class Balance(Base):

--- a/budget/services.py
+++ b/budget/services.py
@@ -4,7 +4,7 @@ import calendar
 import uuid
 from typing import Iterable, Iterator
 
-from .models import Transaction, Recurring, Balance
+from .models import Account, Balance, Recurring, Transaction
 from .services_irregular import irregular_daily_series
 
 
@@ -88,6 +88,24 @@ def occurrences_between(anchor: date, frequency: str, start: date, end: date) ->
     return list(it)
 
 
+def create_transaction(
+    session,
+    account_id: int,
+    description: str,
+    amount: float,
+    when: datetime,
+) -> Transaction:
+    txn = Transaction(
+        account_id=account_id,
+        description=description,
+        amount=amount,
+        timestamp=when,
+    )
+    session.add(txn)
+    session.commit()
+    return txn
+
+
 def create_transfer(
     session,
     from_account_id: int,
@@ -95,29 +113,57 @@ def create_transfer(
     amount: float,
     when: datetime,
     description: str = "Transfer",
-):
-    """Create a two-leg transfer between accounts and return the group id."""
+) -> str:
+    """Create a two-leg transfer between accounts and return the transfer id."""
 
-    gid = str(uuid.uuid4())
+    tid = str(uuid.uuid4())
+    from_acct = session.get(Account, from_account_id)
+    out_desc = description
+    in_desc = description
+    if description.strip().lower() == "transfer" and from_acct:
+        in_desc = f"Transfer from {from_acct.name}"
     t_out = Transaction(
         account_id=from_account_id,
         amount=-abs(amount),
-        description=description,
+        description=out_desc,
         timestamp=when,
-        transfer_group_id=gid,
-        counterparty_account_id=to_account_id,
+        transfer_id=tid,
     )
     t_in = Transaction(
         account_id=to_account_id,
         amount=abs(amount),
-        description=description,
+        description=in_desc,
         timestamp=when,
-        transfer_group_id=gid,
-        counterparty_account_id=from_account_id,
+        transfer_id=tid,
     )
     session.add_all([t_out, t_in])
     session.commit()
-    return gid
+    return tid
+
+
+def delete_transfer(session, transfer_id: str) -> None:
+    txns = session.query(Transaction).filter(Transaction.transfer_id == transfer_id).all()
+    for t in txns:
+        session.delete(t)
+    session.commit()
+
+
+def update_transfer(
+    session,
+    transfer_id: str,
+    description: str,
+    amount: float,
+    when: datetime,
+) -> None:
+    txns = session.query(Transaction).filter(Transaction.transfer_id == transfer_id).all()
+    for t in txns:
+        t.description = description
+        t.timestamp = when
+        if t.amount < 0:
+            t.amount = -abs(amount)
+        else:
+            t.amount = abs(amount)
+    session.commit()
 
 
 def simulate_balances(

--- a/budget/services.py
+++ b/budget/services.py
@@ -4,7 +4,8 @@ import calendar
 import uuid
 from typing import Iterable, Iterator
 
-from .models import Transaction
+from .models import Transaction, Recurring, Balance
+from .services_irregular import irregular_daily_series
 
 
 def add_months(d: date, months: int) -> date:
@@ -117,3 +118,154 @@ def create_transfer(
     session.add_all([t_out, t_in])
     session.commit()
     return gid
+
+
+def simulate_balances(
+    session,
+    start_date: date,
+    end_date: date,
+    account_ids: list[int],
+    candidate_extra: dict[int, float],
+) -> dict[int, list[tuple[date, float]]]:
+    """Return per-account daily balances applying an extra payment today."""
+
+    # Latest balance snapshot per account
+    bal_map: dict[int, tuple[float, datetime]] = {}
+    for aid in account_ids:
+        row = (
+            session.query(Balance)
+            .filter(Balance.account_id == aid)
+            .order_by(Balance.timestamp.desc())
+            .first()
+        )
+        amt = row.amount if row else 0.0
+        ts = (
+            row.timestamp
+            if row and row.timestamp
+            else datetime.combine(date.today(), datetime.min.time())
+        )
+        bal_map[aid] = (amt, ts)
+
+    # Starting balances after posted transactions up to start_date
+    start_balances: dict[int, float] = {}
+    start_dt = datetime.combine(start_date, datetime.max.time())
+    for aid, (bal_amt, bal_ts) in bal_map.items():
+        posted_rows = (
+            session.query(Transaction.amount)
+            .filter(
+                Transaction.account_id == aid,
+                Transaction.timestamp > bal_ts,
+                Transaction.timestamp <= start_dt,
+            )
+            .all()
+        )
+        posted_sum = sum(a for (a,) in posted_rows)
+        start_balances[aid] = bal_amt + posted_sum + candidate_extra.get(aid, 0.0)
+
+    # Collect future events
+    events: list[Transaction] = []
+    end_dt = datetime.combine(end_date, datetime.max.time())
+    txns = (
+        session.query(Transaction)
+        .filter(
+            Transaction.account_id.in_(account_ids),
+            Transaction.timestamp > start_dt,
+            Transaction.timestamp <= end_dt,
+        )
+        .order_by(Transaction.timestamp)
+        .all()
+    )
+    events.extend(txns)
+
+    recs = session.query(Recurring).filter(Recurring.account_id.in_(account_ids)).all()
+    for r in recs:
+        anchor = r.start_date.date() if isinstance(r.start_date, datetime) else r.start_date
+        occs = occurrences_between(anchor, r.frequency, start_date, end_date)
+        for occ in occs:
+            events.append(
+                Transaction(
+                    account_id=r.account_id,
+                    amount=r.amount,
+                    description=r.description,
+                    timestamp=datetime.combine(occ, datetime.min.time()),
+                )
+            )
+
+    for aid in account_ids:
+        irr = irregular_daily_series(
+            session,
+            start_date,
+            end_date,
+            account_id=aid,
+            mode="deterministic",
+            quantile="p80",
+        )
+        for d, amt in irr:
+            if amt:
+                events.append(
+                    Transaction(
+                        account_id=aid,
+                        amount=-amt,
+                        description="Irregular",
+                        timestamp=datetime.combine(d, datetime.min.time()),
+                    )
+                )
+
+    events.sort(
+        key=lambda t: (
+            t.timestamp,
+            t.account_id,
+            t.description or "",
+            t.amount,
+        )
+    )
+
+    balances = {aid: [] for aid in account_ids}
+    running = dict(start_balances)
+    idx = 0
+    curr = start_date
+    while curr <= end_date:
+        while idx < len(events) and events[idx].timestamp.date() <= curr:
+            t = events[idx]
+            running[t.account_id] = running.get(t.account_id, 0.0) + t.amount
+            idx += 1
+        for aid in account_ids:
+            balances[aid].append((curr, running.get(aid, 0.0)))
+        curr += timedelta(days=1)
+
+    return balances
+
+
+def max_safe_payment_today(
+    session,
+    target_account_id: int,
+    buffer_by_account: dict[int, float],
+    horizon_days: int = 120,
+) -> float:
+    """Return max extra payment today without dipping below buffers."""
+
+    start = date.today()
+    end = start + timedelta(days=horizon_days)
+    account_ids = list(buffer_by_account.keys())
+
+    baseline = simulate_balances(session, start, end, account_ids, {})
+    start_balance = next(b for d, b in baseline[target_account_id] if d == start)
+    hi = max(0.0, start_balance - buffer_by_account.get(target_account_id, 0.0))
+    lo = 0.0
+
+    def ok(x: float) -> bool:
+        cand = {target_account_id: -x}
+        sim = simulate_balances(session, start, end, account_ids, cand)
+        for aid, series in sim.items():
+            buf = buffer_by_account.get(aid, 0.0)
+            if any(bal < buf for _, bal in series):
+                return False
+        return True
+
+    while hi - lo > 0.01:
+        mid = (lo + hi) / 2
+        if ok(mid):
+            lo = mid
+        else:
+            hi = mid
+    return round(lo, 2)

--- a/budget/services.py
+++ b/budget/services.py
@@ -268,4 +268,4 @@ def max_safe_payment_today(
             lo = mid
         else:
             hi = mid
-    return round(lo, 2)
+    return round((lo + hi) / 2, 2)

--- a/budget/services.py
+++ b/budget/services.py
@@ -166,6 +166,90 @@ def update_transfer(
     session.commit()
 
 
+def create_recurring_transfer(
+    session,
+    from_account_id: int,
+    to_account_id: int,
+    amount: float,
+    start: datetime,
+    frequency: str,
+    description: str = "Transfer",
+) -> str:
+    """Create a two-leg recurring transfer and return the transfer id."""
+
+    tid = str(uuid.uuid4())
+    from_acct = session.get(Account, from_account_id)
+    out_desc = description
+    in_desc = description
+    if description.strip().lower() == "transfer" and from_acct:
+        in_desc = f"Transfer from {from_acct.name}"
+    r_out = Recurring(
+        account_id=from_account_id,
+        amount=-abs(amount),
+        description=out_desc,
+        start_date=start,
+        frequency=frequency,
+        transfer_id=tid,
+    )
+    r_in = Recurring(
+        account_id=to_account_id,
+        amount=abs(amount),
+        description=in_desc,
+        start_date=start,
+        frequency=frequency,
+        transfer_id=tid,
+    )
+    session.add_all([r_out, r_in])
+    session.commit()
+    return tid
+
+
+def update_recurring_transfer(
+    session,
+    transfer_id: str,
+    description: str,
+    amount: float,
+    start: datetime,
+    frequency: str,
+    from_account_id: int,
+    to_account_id: int,
+) -> None:
+    recs = (
+        session.query(Recurring)
+        .filter(Recurring.transfer_id == transfer_id)
+        .all()
+    )
+    if len(recs) != 2:
+        return
+    from_acct = session.get(Account, from_account_id)
+    in_desc = description
+    if description.strip().lower() == "transfer" and from_acct:
+        in_desc = f"Transfer from {from_acct.name}"
+    for r in recs:
+        if r.amount < 0:
+            r.account_id = from_account_id
+            r.amount = -abs(amount)
+            r.description = description
+        else:
+            r.account_id = to_account_id
+            r.amount = abs(amount)
+            r.description = in_desc
+        r.start_date = start
+        r.frequency = frequency
+    session.commit()
+
+
+def delete_recurring_transfer(session, transfer_id: str) -> None:
+    recs = (
+        session.query(Recurring)
+        .filter(Recurring.transfer_id == transfer_id)
+        .all()
+    )
+    for r in recs:
+        session.delete(r)
+    session.commit()
+
+
 def simulate_balances(
     session,
     start_date: date,

--- a/tests/test_irregular.py
+++ b/tests/test_irregular.py
@@ -22,7 +22,9 @@ def test_learn_state_minimum():
     cat = IrregularCategory(name="Groceries")
     session.add(cat)
     session.commit()
-    session.add(IrregularRule(category_id=cat.id, pattern="walmart"))
+    session.add(
+        IrregularRule(category_id=cat.id, account_id=cat.account_id, pattern="walmart")
+    )
     session.commit()
 
     random.seed(0)
@@ -146,7 +148,7 @@ def test_irregular_daily_series():
     start = date(2024, 1, 2)
     end = start + timedelta(days=59)
 
-    daily = dict(irregular_daily_series(session, start, end))
+    daily = dict(irregular_daily_series(session, start, end, account_id=cat.account_id))
     horizon = (end - start).days + 1
     series = [daily.get(start + timedelta(days=i), 0.0) for i in range(horizon)]
 
@@ -190,7 +192,9 @@ def test_merge_into_ledger(monkeypatch):
 
     start = fixed_today
     end = start + timedelta(days=30)
-    forecast = dict(irregular_daily_series(session, start, end))
+    forecast = dict(
+        irregular_daily_series(session, start, end, account_id=cat.account_id)
+    )
 
     rows = list(itertools.islice(cli.ledger_rows(session), len(forecast)))
     irregular_rows = {(r.date, r.amount) for r in rows if r.description == "Irregular"}

--- a/tests/test_irregular_rules.py
+++ b/tests/test_irregular_rules.py
@@ -15,17 +15,20 @@ def test_rules_for_and_match_category():
 
     session.add_all(
         [
-            IrregularRule(category_id=cat1.id, pattern="auto"),
-            IrregularRule(category_id=cat2.id, pattern="dentist"),
+            IrregularRule(
+                category_id=cat1.id, account_id=cat1.account_id, pattern="auto"
+            ),
+            IrregularRule(
+                category_id=cat2.id, account_id=cat2.account_id, pattern="dentist"
+            ),
         ]
     )
     session.commit()
 
     assert rules_for(session, cat1.id) == ["auto"]
-    assert match_category_id(session, "Paid AUTO shop") == cat1.id
-    assert match_category_id(session, "dentist appointment") == cat2.id
-    assert match_category_id(session, "unknown") is None
+    assert match_category_id(session, "Paid AUTO shop", 1) == cat1.id
+    assert match_category_id(session, "dentist appointment", 1) == cat2.id
+    assert match_category_id(session, "unknown", 1) is None
 
     session.close()
     db_path.unlink()
-

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -207,7 +207,7 @@ def test_ledger_view_displays_all_events(monkeypatch):
 
         captured = {}
 
-        def fake_curses(stdscr, initial_row, get_prev, get_next, bal_amt):
+        def fake_curses(stdscr, initial_row, get_prev, get_next, bal_amt, *args, **kwargs):
             rows = [initial_row]
             while True:
                 prev_row = get_prev(rows[0].timestamp)
@@ -442,7 +442,7 @@ def test_ledger_view_handles_multiple_recurring(monkeypatch):
 
         captured = {}
 
-        def fake_curses(stdscr, initial_row, get_prev, get_next, bal_amt):
+        def fake_curses(stdscr, initial_row, get_prev, get_next, bal_amt, *args, **kwargs):
             rows = [initial_row]
             prev_row = get_prev(rows[0].timestamp)
             if prev_row is not None:

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -210,12 +210,9 @@ def test_ledger_view_displays_all_events(monkeypatch):
         def fake_curses(stdscr, initial_row, get_prev, get_next, bal_amt):
             rows = [initial_row]
             while True:
-                prev = get_prev(rows[0].timestamp)
-                if prev is None:
+                prev_row = get_prev(rows[0].timestamp)
+                if prev_row is None:
                     break
-                prev_row = cli.LedgerRow(
-                    prev[0], prev[1], prev[2], rows[0].running - rows[0].amount
-                )
                 rows.insert(0, prev_row)
                 if len(rows) >= 3:
                     break
@@ -447,19 +444,13 @@ def test_ledger_view_handles_multiple_recurring(monkeypatch):
 
         def fake_curses(stdscr, initial_row, get_prev, get_next, bal_amt):
             rows = [initial_row]
-            prev = get_prev(rows[0].timestamp)
-            if prev is not None:
-                prev_row = cli.LedgerRow(
-                    prev[0], prev[1], prev[2], rows[0].running - rows[0].amount
-                )
+            prev_row = get_prev(rows[0].timestamp)
+            if prev_row is not None:
                 rows.insert(0, prev_row)
             while len(rows) < 4:
-                nxt = get_next(rows[-1].timestamp)
-                if nxt is None:
+                next_row = get_next(rows[-1].timestamp)
+                if next_row is None:
                     break
-                next_row = cli.LedgerRow(
-                    nxt[0], nxt[1], nxt[2], rows[-1].running + nxt[2]
-                )
                 rows.append(next_row)
             captured["rows"] = rows
 

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,5 +1,6 @@
 import itertools
 from datetime import datetime, date, timedelta
+import pytest
 
 from tests.helpers import get_temp_session
 from budget import cli
@@ -537,8 +538,8 @@ def test_per_account_offsets_match_stored_balance():
         for r in rows:
             if r.account_id in bal_ts and r.date <= bal_ts[r.account_id]:
                 last_by_acct[r.account_id] = r
-        assert abs(last_by_acct[a1.id].running_account - 100.0) < 0.01
-        assert abs(last_by_acct[a2.id].running_account - 200.0) < 0.01
+        assert last_by_acct[a1.id].running_account == pytest.approx(100.0, abs=0.01)
+        assert last_by_acct[a2.id].running_account == pytest.approx(200.0, abs=0.01)
     finally:
         session.close()
         path.unlink()

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,9 +1,16 @@
 import itertools
-from datetime import datetime, date
+from datetime import datetime, date, timedelta
 
 from tests.helpers import get_temp_session
 from budget import cli
-from budget.models import Transaction, Balance, Recurring
+from budget.models import (
+    Account,
+    Transaction,
+    Balance,
+    Recurring,
+    IrregularCategory,
+    IrregularState,
+)
 from budget.services import occurrences_between
 
 
@@ -474,4 +481,160 @@ def test_ledger_view_handles_multiple_recurring(monkeypatch):
             running += r.amount
             assert r.running == running
     finally:
+        path.unlink()
+
+def test_per_account_offsets_match_stored_balance():
+    Session, path = get_temp_session()
+    try:
+        session = Session()
+        a1 = Account(name="A", type="checking")
+        a2 = Account(name="B", type="checking")
+        session.add_all([a1, a2])
+        session.commit()
+
+        bal_a = Balance(amount=100.0, timestamp=datetime(2023, 1, 2), account_id=a1.id)
+        bal_b = Balance(amount=200.0, timestamp=datetime(2023, 1, 3), account_id=a2.id)
+        session.add_all([
+            bal_a,
+            bal_b,
+            Transaction(
+                description="preA",
+                amount=-20.0,
+                timestamp=datetime(2023, 1, 1),
+                account_id=a1.id,
+            ),
+            Transaction(
+                description="markA",
+                amount=0.0,
+                timestamp=datetime(2023, 1, 2),
+                account_id=a1.id,
+            ),
+            Transaction(
+                description="preB",
+                amount=50.0,
+                timestamp=datetime(2023, 1, 2),
+                account_id=a2.id,
+            ),
+            Transaction(
+                description="markB",
+                amount=0.0,
+                timestamp=datetime(2023, 1, 3),
+                account_id=a2.id,
+            ),
+        ])
+        session.commit()
+
+        rows = list(
+            cli.ledger_rows(
+                session,
+                date(2023, 1, 1),
+                date(2023, 1, 5),
+                [a1.id, a2.id],
+            )
+        )
+        last_by_acct = {}
+        bal_ts = {a1.id: date(2023, 1, 2), a2.id: date(2023, 1, 3)}
+        for r in rows:
+            if r.account_id in bal_ts and r.date <= bal_ts[r.account_id]:
+                last_by_acct[r.account_id] = r
+        assert abs(last_by_acct[a1.id].running_account - 100.0) < 0.01
+        assert abs(last_by_acct[a2.id].running_account - 200.0) < 0.01
+    finally:
+        session.close()
+        path.unlink()
+
+
+def test_overlap_consistency_multi_account():
+    Session, path = get_temp_session()
+    try:
+        session = Session()
+        a1 = Account(name="A", type="checking")
+        a2 = Account(name="B", type="checking")
+        session.add_all([a1, a2])
+        session.commit()
+        session.add_all([
+            Balance(amount=0.0, timestamp=datetime(2023, 1, 1), account_id=a1.id),
+            Balance(amount=0.0, timestamp=datetime(2023, 1, 1), account_id=a2.id),
+            Transaction(
+                description="A Jan",
+                amount=100.0,
+                timestamp=datetime(2023, 1, 5),
+                account_id=a1.id,
+            ),
+            Transaction(
+                description="A Apr",
+                amount=-20.0,
+                timestamp=datetime(2023, 4, 5),
+                account_id=a1.id,
+            ),
+            Transaction(
+                description="B Feb",
+                amount=50.0,
+                timestamp=datetime(2023, 2, 5),
+                account_id=a2.id,
+            ),
+            Transaction(
+                description="B May",
+                amount=-10.0,
+                timestamp=datetime(2023, 5, 5),
+                account_id=a2.id,
+            ),
+        ])
+        session.commit()
+        start = date(2023, 1, 1)
+        rows_a = list(
+            cli.ledger_rows(session, start, date(2023, 3, 31), [a1.id, a2.id])
+        )
+        rows_b = list(
+            cli.ledger_rows(session, start, date(2023, 6, 30), [a1.id, a2.id])
+        )
+        rows_b_trim = [r for r in rows_b if r.date <= date(2023, 3, 31)]
+        assert [
+            (r.timestamp, r.account_id, r.description, r.amount, r.running_account, r.running_total)
+            for r in rows_a
+        ] == [
+            (r.timestamp, r.account_id, r.description, r.amount, r.running_account, r.running_total)
+            for r in rows_b_trim
+        ]
+    finally:
+        session.close()
+        path.unlink()
+
+
+def test_irregular_account_scope():
+    Session, path = get_temp_session()
+    try:
+        session = Session()
+        a1 = Account(name="A", type="checking")
+        a2 = Account(name="B", type="checking")
+        session.add_all([a1, a2])
+        session.commit()
+        today = date.today()
+        session.add_all([
+            Balance(amount=0.0, timestamp=datetime.combine(today, datetime.min.time()), account_id=a1.id),
+            Balance(amount=0.0, timestamp=datetime.combine(today, datetime.min.time()), account_id=a2.id),
+            IrregularCategory(
+                name="Car",
+                account_id=a1.id,
+                state=IrregularState(
+                    avg_gap_days=30.0,
+                    median_amount=100.0,
+                    last_event_at=datetime.combine(today - timedelta(days=30), datetime.min.time()),
+                ),
+            ),
+        ])
+        session.commit()
+        rows = list(
+            cli.ledger_rows(
+                session,
+                today,
+                today + timedelta(days=60),
+                [a1.id, a2.id],
+            )
+        )
+        irregular_rows = [r for r in rows if r.description == "Irregular"]
+        assert irregular_rows, "expected irregular events for account A"
+        assert all(r.account_id == a1.id for r in irregular_rows)
+    finally:
+        session.close()
         path.unlink()

--- a/tests/test_max_payment.py
+++ b/tests/test_max_payment.py
@@ -1,0 +1,62 @@
+from datetime import date, datetime, timedelta
+
+from budget.models import Balance, Recurring
+from budget.services import max_safe_payment_today, simulate_balances
+from tests.helpers import get_temp_session
+
+
+def test_max_safe_payment_today():
+    Session, _ = get_temp_session()
+    session = Session()
+
+    today = date.today()
+
+    # starting balance
+    session.add(
+        Balance(
+            amount=1000.0,
+            timestamp=datetime.combine(today, datetime.min.time()),
+            account_id=1,
+        )
+    )
+
+    # upcoming expense in 30 days
+    session.add(
+        Recurring(
+            description="Rent",
+            amount=-400.0,
+            start_date=datetime.combine(today + timedelta(days=30), datetime.min.time()),
+            frequency="monthly",
+            account_id=1,
+        )
+    )
+
+    session.commit()
+
+    buffers = {1: 100.0}
+
+    safe = max_safe_payment_today(session, 1, buffers, horizon_days=59)
+    assert abs(safe - 500.0) < 0.02
+
+    # safe amount keeps balance above buffer
+    balances_safe = simulate_balances(
+        session,
+        today,
+        today + timedelta(days=59),
+        [1],
+        {1: -safe},
+    )
+    assert all(b >= 100.0 for _, b in balances_safe[1])
+
+    # paying one more dollar violates buffer
+    balances_too_much = simulate_balances(
+        session,
+        today,
+        today + timedelta(days=59),
+        [1],
+        {1: -(safe + 1)},
+    )
+    assert any(b < 100.0 for _, b in balances_too_much[1])
+
+    session.close()
+

--- a/tests/test_safe_payment.py
+++ b/tests/test_safe_payment.py
@@ -5,7 +5,7 @@ from budget.services import max_safe_payment_today, simulate_balances
 from tests.helpers import get_temp_session
 
 
-def test_max_safe_payment_today():
+def test_max_safe_payment_monotonic():
     Session, _ = get_temp_session()
     session = Session()
 
@@ -36,6 +36,7 @@ def test_max_safe_payment_today():
     buffers = {1: 100.0}
 
     safe = max_safe_payment_today(session, 1, buffers, horizon_days=59)
+    safe = round(safe, 2)
     assert abs(safe - 500.0) < 0.02
 
     # safe amount keeps balance above buffer
@@ -48,13 +49,13 @@ def test_max_safe_payment_today():
     )
     assert all(b >= 100.0 for _, b in balances_safe[1])
 
-    # paying one more dollar violates buffer
+    # paying slightly more violates buffer
     balances_too_much = simulate_balances(
         session,
         today,
         today + timedelta(days=59),
         [1],
-        {1: -(safe + 1)},
+        {1: -(safe + 0.01)},
     )
     assert any(b < 100.0 for _, b in balances_too_much[1])
 

--- a/tests/test_safe_payment.py
+++ b/tests/test_safe_payment.py
@@ -6,58 +6,60 @@ from tests.helpers import get_temp_session
 
 
 def test_max_safe_payment_monotonic():
-    Session, _ = get_temp_session()
-    session = Session()
+    Session, path = get_temp_session()
+    try:
+        session = Session()
 
-    today = date.today()
+        today = date.today()
 
-    # starting balance
-    session.add(
-        Balance(
-            amount=1000.0,
-            timestamp=datetime.combine(today, datetime.min.time()),
-            account_id=1,
+        # starting balance
+        session.add(
+            Balance(
+                amount=1000.0,
+                timestamp=datetime.combine(today, datetime.min.time()),
+                account_id=1,
+            )
         )
-    )
 
-    # upcoming expense in 30 days
-    session.add(
-        Recurring(
-            description="Rent",
-            amount=-400.0,
-            start_date=datetime.combine(today + timedelta(days=30), datetime.min.time()),
-            frequency="monthly",
-            account_id=1,
+        # upcoming expense in 30 days
+        session.add(
+            Recurring(
+                description="Rent",
+                amount=-400.0,
+                start_date=datetime.combine(today + timedelta(days=30), datetime.min.time()),
+                frequency="monthly",
+                account_id=1,
+            )
         )
-    )
 
-    session.commit()
+        session.commit()
 
-    buffers = {1: 100.0}
+        buffers = {1: 100.0}
 
-    safe = max_safe_payment_today(session, 1, buffers, horizon_days=59)
-    safe = round(safe, 2)
-    assert abs(safe - 500.0) < 0.02
+        safe = max_safe_payment_today(session, 1, buffers, horizon_days=59)
+        safe = round(safe, 2)
+        assert abs(safe - 500.0) < 0.02
 
-    # safe amount keeps balance above buffer
-    balances_safe = simulate_balances(
-        session,
-        today,
-        today + timedelta(days=59),
-        [1],
-        {1: -safe},
-    )
-    assert all(b >= 100.0 for _, b in balances_safe[1])
+        # safe amount keeps balance above buffer
+        balances_safe = simulate_balances(
+            session,
+            today,
+            today + timedelta(days=59),
+            [1],
+            {1: -safe},
+        )
+        assert all(b >= 100.0 for _, b in balances_safe[1])
 
-    # paying slightly more violates buffer
-    balances_too_much = simulate_balances(
-        session,
-        today,
-        today + timedelta(days=59),
-        [1],
-        {1: -(safe + 0.01)},
-    )
-    assert any(b < 100.0 for _, b in balances_too_much[1])
-
-    session.close()
+        # paying slightly more violates buffer
+        balances_too_much = simulate_balances(
+            session,
+            today,
+            today + timedelta(days=59),
+            [1],
+            {1: -(safe + 0.01)},
+        )
+        assert any(b < 100.0 for _, b in balances_too_much[1])
+    finally:
+        session.close()
+        path.unlink()
 

--- a/tests/test_transaction_actions.py
+++ b/tests/test_transaction_actions.py
@@ -58,18 +58,14 @@ def test_edit_transaction(monkeypatch):
     Session, path = get_temp_session()
     try:
         session = Session()
-        txn = Transaction(
-            description="Old", amount=5.0, timestamp=datetime(2023, 1, 1)
-        )
+        txn = Transaction(description="Old", amount=5.0, timestamp=datetime(2023, 1, 1))
         session.add(txn)
         session.commit()
 
         monkeypatch.setattr(
             cli, "select", make_prompt(["description", "amount", "date", "save"])
         )
-        monkeypatch.setattr(
-            cli, "text", make_prompt(["New", "10.0", "2023-03-03"])
-        )
+        monkeypatch.setattr(cli, "text", make_prompt(["New", "10.0", "2023-03-03"]))
 
         cli.edit_transaction(object(), session, txn)
         session.refresh(txn)
@@ -102,8 +98,12 @@ def test_list_transactions_columns(monkeypatch):
         session = Session()
         session.add_all(
             [
-                Transaction(description="Short", amount=5.0, timestamp=datetime(2023, 1, 1)),
-                Transaction(description="Longer", amount=-3.0, timestamp=datetime(2023, 1, 2)),
+                Transaction(
+                    description="Short", amount=5.0, timestamp=datetime(2023, 1, 1)
+                ),
+                Transaction(
+                    description="Longer", amount=-3.0, timestamp=datetime(2023, 1, 2)
+                ),
             ]
         )
         session.commit()
@@ -208,7 +208,11 @@ def test_add_transaction_updates_irregular_state(monkeypatch):
         session.add(cat)
         session.commit()
         cat_id = cat.id
-        session.add(IrregularRule(category_id=cat_id, pattern="grocer"))
+        session.add(
+            IrregularRule(
+                category_id=cat_id, account_id=cat.account_id, pattern="grocer"
+            )
+        )
         session.commit()
         session.close()
 

--- a/tests/test_transaction_actions.py
+++ b/tests/test_transaction_actions.py
@@ -8,6 +8,7 @@ from budget.models import (
     IrregularCategory,
     IrregularRule,
     IrregularState,
+    Account,
 )
 
 
@@ -31,15 +32,24 @@ def test_transaction_persistence():
 
 def test_add_transaction_with_date(monkeypatch):
     Session, path = get_temp_session()
+    session = None
     try:
         monkeypatch.setattr(cli, "SessionLocal", Session)
         monkeypatch.setattr(
-            cli, "select", make_prompt(["description", "date", "amount", "save"])
+            cli,
+            "pick_account",
+            lambda stdscr, session, prompt="From account", default=None: session.get(Account, 1),
         )
         monkeypatch.setattr(
-            cli, "text", make_prompt(["Groceries", "2023-02-01", "20.5"])
+            cli,
+            "transaction_form",
+            lambda stdscr, sess, from_acct, d, t, a, to=None: (
+                "Groceries",
+                datetime(2023, 2, 1),
+                20.5,
+                None,
+            ),
         )
-        monkeypatch.setattr(cli, "CURRENT_ACCOUNT_IDS", [1], raising=False)
 
         cli.add_transaction(object())
 
@@ -51,7 +61,8 @@ def test_add_transaction_with_date(monkeypatch):
         assert txn.amount == 20.5
         assert txn.timestamp.date() == datetime(2023, 2, 1).date()
     finally:
-        session.close()
+        if session is not None:
+            session.close()
         path.unlink()
 
 
@@ -64,7 +75,7 @@ def test_edit_transaction(monkeypatch):
         session.commit()
 
         monkeypatch.setattr(
-            cli, "select", make_prompt(["description", "amount", "date", "save"])
+            cli, "select", make_prompt(["name", "amount", "date", "save"])
         )
         monkeypatch.setattr(cli, "text", make_prompt(["New", "10.0", "2023-03-03"]))
 
@@ -227,8 +238,18 @@ def test_add_transaction_updates_irregular_state(monkeypatch):
         monkeypatch.setattr(cli, "SessionLocal", Session)
         monkeypatch.setattr(
             cli,
+            "pick_account",
+            lambda stdscr, session, prompt="From account", default=None: session.get(Account, 1),
+        )
+        monkeypatch.setattr(
+            cli,
             "transaction_form",
-            lambda stdscr, d, t, a: ("Local Grocer", datetime(2023, 4, 2), -20.0),
+            lambda stdscr, sess, from_acct, d, t, a, to=None: (
+                "Local Grocer",
+                datetime(2023, 4, 2),
+                -20.0,
+                None,
+            ),
         )
         captured = {}
 
@@ -236,7 +257,6 @@ def test_add_transaction_updates_irregular_state(monkeypatch):
             captured["msg"] = msg
 
         monkeypatch.setattr(cli, "toast", fake_toast)
-        monkeypatch.setattr(cli, "CURRENT_ACCOUNT_IDS", [1], raising=False)
 
         cli.add_transaction(object())
 

--- a/tests/test_transaction_actions.py
+++ b/tests/test_transaction_actions.py
@@ -39,6 +39,7 @@ def test_add_transaction_with_date(monkeypatch):
         monkeypatch.setattr(
             cli, "text", make_prompt(["Groceries", "2023-02-01", "20.5"])
         )
+        monkeypatch.setattr(cli, "CURRENT_ACCOUNT_IDS", [1], raising=False)
 
         cli.add_transaction(object())
 
@@ -229,6 +230,7 @@ def test_add_transaction_updates_irregular_state(monkeypatch):
             captured["msg"] = msg
 
         monkeypatch.setattr(cli, "toast", fake_toast)
+        monkeypatch.setattr(cli, "CURRENT_ACCOUNT_IDS", [1], raising=False)
 
         cli.add_transaction(object())
 

--- a/tests/test_transaction_actions.py
+++ b/tests/test_transaction_actions.py
@@ -83,9 +83,15 @@ def test_set_balance(monkeypatch):
     try:
         monkeypatch.setattr(cli, "SessionLocal", Session)
         monkeypatch.setattr(cli, "text", make_prompt(["100.0"]))
+        monkeypatch.setattr(cli, "CURRENT_ACCOUNT_IDS", [1], raising=False)
         cli.set_balance(object())
         session = Session()
-        bal = session.get(Balance, 1)
+        bal = (
+            session.query(Balance)
+            .filter(Balance.account_id == 1)
+            .order_by(Balance.timestamp.desc())
+            .first()
+        )
         assert bal is not None
         assert bal.amount == 100.0
     finally:

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+
+from budget.services import create_transfer
+from budget.models import Account, Transaction
+from tests.helpers import get_temp_session
+
+
+def test_create_transfer_zero_sum():
+    Session, path = get_temp_session()
+    try:
+        session = Session()
+        a1 = Account(name="A", type="checking")
+        a2 = Account(name="B", type="checking")
+        session.add_all([a1, a2])
+        session.commit()
+
+        gid = create_transfer(session, a1.id, a2.id, 50.0, datetime(2023, 1, 1))
+
+        txns = session.query(Transaction).filter(Transaction.transfer_group_id == gid).all()
+        assert len(txns) == 2
+        assert sum(t.amount for t in txns) == 0.0
+
+        out = next(t for t in txns if t.account_id == a1.id)
+        inc = next(t for t in txns if t.account_id == a2.id)
+        assert out.amount == -50.0
+        assert inc.amount == 50.0
+        assert out.counterparty_account_id == a2.id
+        assert inc.counterparty_account_id == a1.id
+    finally:
+        session.close()
+        path.unlink()

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -1,17 +1,23 @@
-from datetime import datetime
+from datetime import datetime, date
 
 from budget.services import create_transfer
-from budget.models import Account, Transaction
+from budget.models import Account, Transaction, Balance
+from budget import cli
 from tests.helpers import get_temp_session
 
 
-def test_create_transfer_zero_sum():
+def test_transfers_zero_sum():
     Session, path = get_temp_session()
     try:
         session = Session()
         a1 = Account(name="A", type="checking")
         a2 = Account(name="B", type="checking")
         session.add_all([a1, a2])
+        session.commit()
+        session.add_all([
+            Balance(amount=0.0, timestamp=datetime(2023, 1, 1), account_id=a1.id),
+            Balance(amount=0.0, timestamp=datetime(2023, 1, 1), account_id=a2.id),
+        ])
         session.commit()
 
         gid = create_transfer(session, a1.id, a2.id, 50.0, datetime(2023, 1, 1))
@@ -26,6 +32,22 @@ def test_create_transfer_zero_sum():
         assert inc.amount == 50.0
         assert out.counterparty_account_id == a2.id
         assert inc.counterparty_account_id == a1.id
+
+        rows_a = list(
+            cli.ledger_rows(session, date(2023, 1, 1), date(2023, 1, 2), [a1.id])
+        )
+        rows_b = list(
+            cli.ledger_rows(session, date(2023, 1, 1), date(2023, 1, 2), [a2.id])
+        )
+        rows_ab = list(
+            cli.ledger_rows(session, date(2023, 1, 1), date(2023, 1, 2), [a1.id, a2.id])
+        )
+        assert [(r.account_id, r.amount) for r in rows_a] == [(a1.id, -50.0)]
+        assert [(r.account_id, r.amount) for r in rows_b] == [(a2.id, 50.0)]
+        assert sorted((r.account_id, r.amount) for r in rows_ab) == [
+            (a1.id, -50.0),
+            (a2.id, 50.0),
+        ]
     finally:
         session.close()
         path.unlink()

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -1,6 +1,6 @@
 from datetime import datetime, date
 
-from budget.services import create_transfer
+from budget.services import create_transfer, delete_transfer, update_transfer
 from budget.models import Account, Transaction, Balance
 from budget import cli
 from tests.helpers import get_temp_session
@@ -20,9 +20,9 @@ def test_transfers_zero_sum():
         ])
         session.commit()
 
-        gid = create_transfer(session, a1.id, a2.id, 50.0, datetime(2023, 1, 1))
+        tid = create_transfer(session, a1.id, a2.id, 50.0, datetime(2023, 1, 1))
 
-        txns = session.query(Transaction).filter(Transaction.transfer_group_id == gid).all()
+        txns = session.query(Transaction).filter(Transaction.transfer_id == tid).all()
         assert len(txns) == 2
         assert sum(t.amount for t in txns) == 0.0
 
@@ -30,8 +30,10 @@ def test_transfers_zero_sum():
         inc = next(t for t in txns if t.account_id == a2.id)
         assert out.amount == -50.0
         assert inc.amount == 50.0
-        assert out.counterparty_account_id == a2.id
-        assert inc.counterparty_account_id == a1.id
+
+        update_transfer(session, tid, "Xfer", 60.0, datetime(2023, 1, 2))
+        txns = session.query(Transaction).filter(Transaction.transfer_id == tid).all()
+        assert sorted(t.amount for t in txns) == [-60.0, 60.0]
 
         rows_a = list(
             cli.ledger_rows(session, date(2023, 1, 1), date(2023, 1, 2), [a1.id])
@@ -42,12 +44,17 @@ def test_transfers_zero_sum():
         rows_ab = list(
             cli.ledger_rows(session, date(2023, 1, 1), date(2023, 1, 2), [a1.id, a2.id])
         )
-        assert [(r.account_id, r.amount) for r in rows_a] == [(a1.id, -50.0)]
-        assert [(r.account_id, r.amount) for r in rows_b] == [(a2.id, 50.0)]
+        assert [(r.account_id, r.amount) for r in rows_a] == [(a1.id, -60.0)]
+        assert [(r.account_id, r.amount) for r in rows_b] == [(a2.id, 60.0)]
         assert sorted((r.account_id, r.amount) for r in rows_ab) == [
-            (a1.id, -50.0),
-            (a2.id, 50.0),
+            (a1.id, -60.0),
+            (a2.id, 60.0),
         ]
+
+        delete_transfer(session, tid)
+        assert (
+            session.query(Transaction).filter(Transaction.transfer_id == tid).count() == 0
+        )
     finally:
         session.close()
         path.unlink()

--- a/tests/test_ui_components.py
+++ b/tests/test_ui_components.py
@@ -15,6 +15,7 @@ def test_select_uses_scroll_menu(monkeypatch):
         return 1  # choose second item
 
     monkeypatch.setattr(cli, "scroll_menu", fake_scroll)
+    monkeypatch.setattr(cli, "list_accounts", lambda s: [])
 
     class DummySession:
         def get(self, model, ident):
@@ -259,6 +260,7 @@ def test_select_returns_none_on_quit(monkeypatch):
         return None
 
     monkeypatch.setattr(cli, "scroll_menu", fake_scroll)
+    monkeypatch.setattr(cli, "list_accounts", lambda s: [])
 
     class DummySession:
         def get(self, model, ident):


### PR DESCRIPTION
## Summary
- convert balances to per-account snapshots with composite index
- seed "Default Checking" account and migrate legacy rows
- compute per-account ledger offsets and running totals

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689768821aa88328a6b01feadd125d1e