### PR TITLE
Reset ledger calculations using latest balance

### DIFF
--- a/budget/cli.py
+++ b/budget/cli.py
@@ -1156,19 +1156,55 @@ def projected_balance_on(session, account_id: int, as_of: date) -> float:
 
 
 def display_balance_as_of(session, account_id: int, as_of: date) -> float:
-    """Return running balance for account at ``as_of`` using ledger rules."""
-    rows = [r for r in ledger_rows(session, as_of, as_of, account_ids=[account_id])]
-    if not rows:
-        fb = get_first_balance(session, account_id)
-        start_d = fb.timestamp.date() if fb else (
-            earliest_posted_tx_date(session, account_id) or as_of
+    """Return balance using stored snapshots and posted transactions."""
+    day_end = datetime.combine(as_of, time.max)
+
+    last_bal = (
+        session.query(Balance)
+        .filter(Balance.account_id == account_id, Balance.timestamp <= day_end)
+        .order_by(Balance.timestamp.desc())
+        .first()
+    )
+    if last_bal is not None:
+        base = last_bal.amount or 0.0
+        tx_sum = (
+            session.query(func.coalesce(func.sum(Transaction.amount), 0.0))
+            .filter(
+                Transaction.account_id == account_id,
+                Transaction.timestamp > last_bal.timestamp,
+                Transaction.timestamp <= day_end,
+            )
+            .scalar()
         )
-        rows = [
-            r
-            for r in ledger_rows(session, start_d, as_of, account_ids=[account_id])
-            if r.timestamp.date() <= as_of
-        ]
-    return rows[-1].running_account if rows else 0.0
+        return float(round(base + (tx_sum or 0.0), 2))
+
+    next_bal = (
+        session.query(Balance)
+        .filter(Balance.account_id == account_id, Balance.timestamp > day_end)
+        .order_by(Balance.timestamp.asc())
+        .first()
+    )
+    if next_bal is not None:
+        tx_sum = (
+            session.query(func.coalesce(func.sum(Transaction.amount), 0.0))
+            .filter(
+                Transaction.account_id == account_id,
+                Transaction.timestamp > day_end,
+                Transaction.timestamp <= next_bal.timestamp,
+            )
+            .scalar()
+        )
+        return float(round((next_bal.amount or 0.0) - (tx_sum or 0.0), 2))
+
+    tx_sum = (
+        session.query(func.coalesce(func.sum(Transaction.amount), 0.0))
+        .filter(
+            Transaction.account_id == account_id,
+            Transaction.timestamp <= day_end,
+        )
+        .scalar()
+    )
+    return float(round(tx_sum or 0.0, 2))
 
 
 def list_transactions_since_checkpoint(
@@ -1680,6 +1716,16 @@ def ledger_rows(
         filtered.append(t)
     txns = filtered
 
+    balances = (
+        session.query(Balance)
+        .filter(Balance.account_id.in_(account_ids))
+        .order_by(Balance.timestamp)
+        .all()
+    )
+    balances_by_acct: dict[int, list[Balance]] = defaultdict(list)
+    for b in balances:
+        balances_by_acct[b.account_id].append(b)
+
     def classify_priority(t):
         src = getattr(t, "_source_type", "posted")
         amt = t.amount or 0.0
@@ -1730,6 +1776,7 @@ def ledger_rows(
         offset[aid] = bal_amt - total_before
 
     running_by_acct: defaultdict[int, float] = defaultdict(float)
+    bal_pos = {aid: 0 for aid in account_ids}
     last_ts: datetime | None = None
     bump = 0
     for t in txns:
@@ -1737,6 +1784,13 @@ def ledger_rows(
             continue
         aid = t.account_id
         ts_d = t.timestamp.date()
+        # apply any balances up to this transaction
+        bal_list = balances_by_acct.get(aid, [])
+        while bal_pos[aid] < len(bal_list) and bal_list[bal_pos[aid]].timestamp <= t.timestamp:
+            offset[aid] = bal_list[bal_pos[aid]].amount or 0.0
+            running_by_acct[aid] = 0.0
+            bal_pos[aid] += 1
+
         src = getattr(t, "_source_type", "posted")
         first_ts_d = first_bal_ts[aid].date()
         if ts_d < first_ts_d:

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -35,6 +35,49 @@ def test_ledger_running_balance():
         path.unlink()
 
 
+def test_ledger_resets_after_balance():
+    Session, path = get_temp_session()
+    try:
+        session = Session()
+        session.add_all(
+            [
+                Balance(amount=500.0, timestamp=datetime(2023, 1, 1)),
+                Transaction(description="T1", amount=70.0, timestamp=datetime(2023, 1, 2)),
+                Transaction(description="T2", amount=-30.0, timestamp=datetime(2023, 1, 3)),
+                Balance(amount=300.0, timestamp=datetime(2023, 1, 4)),
+                Transaction(description="T3", amount=33.0, timestamp=datetime(2023, 1, 5)),
+            ]
+        )
+        session.commit()
+        rows = list(cli.ledger_rows(session))
+        assert [r.running for r in rows] == [570.0, 540.0, 333.0]
+    finally:
+        session.close()
+        path.unlink()
+
+
+def test_display_balance_uses_latest_snapshot():
+    Session, path = get_temp_session()
+    try:
+        session = Session()
+        session.add_all(
+            [
+                Balance(amount=500.0, timestamp=datetime(2023, 1, 1)),
+                Transaction(description="T1", amount=70.0, timestamp=datetime(2023, 1, 2)),
+                Transaction(description="T2", amount=-30.0, timestamp=datetime(2023, 1, 3)),
+                Balance(amount=300.0, timestamp=datetime(2023, 1, 4)),
+                Transaction(description="T3", amount=33.0, timestamp=datetime(2023, 1, 5)),
+            ]
+        )
+        session.commit()
+        assert cli.display_balance_as_of(session, 1, date(2023, 1, 3)) == 540.0
+        assert cli.display_balance_as_of(session, 1, date(2023, 1, 4)) == 300.0
+        assert cli.display_balance_as_of(session, 1, date(2023, 1, 5)) == 333.0
+    finally:
+        session.close()
+        path.unlink()
+
+
 def test_ledger_includes_recurring():
     Session, path = get_temp_session()
     try:


### PR DESCRIPTION
## Summary
- reset running ledger offsets when new balance snapshots are encountered
- compute balance display from most recent stored balance plus later transactions
- test ledger reset behavior and balance display

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b535354508328825d17bf1cbe5ef9