### PR TITLE
Handle ledger resets using latest balances

### DIFF
--- a/budget/cli.py
+++ b/budget/cli.py
@@ -1156,19 +1156,26 @@ def projected_balance_on(session, account_id: int, as_of: date) -> float:
 
 
 def display_balance_as_of(session, account_id: int, as_of: date) -> float:
-    """Return running balance for account at ``as_of`` using ledger rules."""
-    rows = [r for r in ledger_rows(session, as_of, as_of, account_ids=[account_id])]
-    if not rows:
-        fb = get_first_balance(session, account_id)
-        start_d = fb.timestamp.date() if fb else (
-            earliest_posted_tx_date(session, account_id) or as_of
+    """Return balance using latest stored balance plus subsequent transactions."""
+    end_dt = datetime.combine(as_of, datetime.max.time())
+    bal = (
+        session.query(Balance)
+        .filter(Balance.account_id == account_id, Balance.timestamp <= end_dt)
+        .order_by(Balance.timestamp.desc())
+        .first()
+    )
+    bal_amt = bal.amount if bal else 0.0
+    bal_ts = bal.timestamp if bal else datetime.combine(as_of, time.min)
+    total = (
+        session.query(func.coalesce(func.sum(Transaction.amount), 0.0))
+        .filter(
+            Transaction.account_id == account_id,
+            Transaction.timestamp > bal_ts,
+            Transaction.timestamp <= end_dt,
         )
-        rows = [
-            r
-            for r in ledger_rows(session, start_d, as_of, account_ids=[account_id])
-            if r.timestamp.date() <= as_of
-        ]
-    return rows[-1].running_account if rows else 0.0
+        .scalar()
+    )
+    return bal_amt + (total or 0.0)
 
 
 def list_transactions_since_checkpoint(
@@ -1663,6 +1670,25 @@ def ledger_rows(
     for t in irr_series:
         setattr(t, "_source_type", "irregular")
 
+    balance_rows = (
+        session.query(Balance)
+        .filter(Balance.account_id.in_(account_ids))
+        .all()
+    )
+    balance_events: list[Transaction] = []
+    for b in balance_rows:
+        balance_events.append(
+            Transaction(
+                description="Balance",
+                amount=b.amount,
+                timestamp=b.timestamp,
+                account_id=b.account_id,
+            )
+        )
+    for t in balance_events:
+        setattr(t, "_source_type", "balance")
+    txns.extend(balance_events)
+
     def _synthetic_overlaps_posted(t: Transaction) -> bool:
         return _overlaps_posted(
             posted_idx,
@@ -1675,7 +1701,7 @@ def ledger_rows(
     filtered: list[Transaction] = []
     for t in txns:
         src = getattr(t, "_source_type", "posted")
-        if src != "posted" and _synthetic_overlaps_posted(t):
+        if src not in ("posted", "balance") and _synthetic_overlaps_posted(t):
             continue
         filtered.append(t)
     txns = filtered
@@ -1687,6 +1713,8 @@ def ledger_rows(
             return (50, 0)
         if src == "recurring":
             return (20, 0) if amt > 0 else (30, 0)
+        if src == "balance":
+            return (0, 0)
         return (20, 0) if amt > 0 else (40, 0)
 
     def _ledger_sort_key(t: Transaction):
@@ -1733,11 +1761,16 @@ def ledger_rows(
     last_ts: datetime | None = None
     bump = 0
     for t in txns:
-        if not (plan_start <= t.timestamp.date() <= plan_end):
-            continue
         aid = t.account_id
         ts_d = t.timestamp.date()
         src = getattr(t, "_source_type", "posted")
+        if src == "balance":
+            display_running = running_by_acct[aid] + offset[aid]
+            diff = (t.amount or 0.0) - display_running
+            offset[aid] += diff
+            continue
+        if not (plan_start <= ts_d <= plan_end):
+            continue
         first_ts_d = first_bal_ts[aid].date()
         if ts_d < first_ts_d:
             eff = t.amount or 0.0

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -35,6 +35,58 @@ def test_ledger_running_balance():
         path.unlink()
 
 
+def test_ledger_resets_after_balance():
+    Session, path = get_temp_session()
+    try:
+        session = Session()
+        session.add_all(
+            [
+                Transaction(description="T1", amount=-45.0, timestamp=datetime(2023, 1, 1)),
+                Transaction(description="T2", amount=-65.0, timestamp=datetime(2023, 1, 2)),
+                Transaction(description="T3", amount=75.0, timestamp=datetime(2023, 1, 3)),
+                Transaction(description="T4", amount=55.0, timestamp=datetime(2023, 1, 4)),
+                Balance(amount=500.0, timestamp=datetime(2023, 1, 5)),
+                Transaction(description="T5", amount=70.0, timestamp=datetime(2023, 1, 6)),
+                Transaction(description="T6", amount=-30.0, timestamp=datetime(2023, 1, 7)),
+                Balance(amount=300.0, timestamp=datetime(2023, 1, 8)),
+                Transaction(description="T7", amount=33.0, timestamp=datetime(2023, 1, 9)),
+                Transaction(description="T8", amount=-400.0, timestamp=datetime(2023, 1, 10)),
+                Transaction(description="T9", amount=40.0, timestamp=datetime(2023, 1, 11)),
+            ]
+        )
+        session.commit()
+        rows = list(cli.ledger_rows(session))
+        running = {r.description: r.running_account for r in rows}
+        assert running["T6"] == 540.0
+        assert running["T7"] == 333.0
+        assert running["T8"] == -67.0
+        assert running["T9"] == -27.0
+    finally:
+        session.close()
+        path.unlink()
+
+
+def test_display_balance_as_of_uses_latest_balance():
+    Session, path = get_temp_session()
+    try:
+        session = Session()
+        session.add_all(
+            [
+                Balance(amount=100.0, timestamp=datetime(2023, 1, 1)),
+                Transaction(description="A", amount=50.0, timestamp=datetime(2023, 1, 2)),
+                Balance(amount=120.0, timestamp=datetime(2023, 1, 3)),
+                Transaction(description="B", amount=-20.0, timestamp=datetime(2023, 1, 4)),
+            ]
+        )
+        session.commit()
+        assert cli.display_balance_as_of(session, 1, date(2023, 1, 2)) == 150.0
+        assert cli.display_balance_as_of(session, 1, date(2023, 1, 3)) == 120.0
+        assert cli.display_balance_as_of(session, 1, date(2023, 1, 4)) == 100.0
+    finally:
+        session.close()
+        path.unlink()
+
+
 def test_ledger_includes_recurring():
     Session, path = get_temp_session()
     try:


### PR DESCRIPTION
## Summary
- compute balance as of a date from most recent stored balance plus subsequent transactions
- adjust ledger calculations to reset when encountering later balance snapshots
- add tests covering multiple balances and the new balance lookup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b535354508328825d17bf1cbe5ef9